### PR TITLE
use ply main branch instead of release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 # Definitions to get versions of python3 PyCifRW and PLY
 #
 PY3CIFRW ?= PyCifRW-4.3_rev_19Jun21
-PY3PLY = ply-3.11
+PY3PLY = ply
 PY3CIFRWFLAG = -DCBF_USE_PYCIFRW
 PY3CIFRW_PREFIX ?= $(HOME)/.local
 endif
@@ -765,7 +765,7 @@ PY2PLYURL      = http://www.dabeaz.com/ply/$(PY2PLY).tar.gz
 endif
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 PY3CIFRWURL     = http://downloads.sf.net/cbflib/$(PY3CIFRW).tar.gz
-PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
+PY3PLYURL       = https://github.com/dabeaz/ply.git
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
@@ -1513,10 +1513,7 @@ build_py3ply:   $(M4)/Makefile.m4
 	touch build_py3ply
 $(PY3PLY):      build_py3ply
 	-rm -rf $(PY3PLY)
-	-rm -rf $(PY3PLY).tar.gz
-	$(DOWNLOAD) $(PY3PLYURL)
-	tar -xvf $(PY3PLY).tar.gz
-	-rm $(PY3PLY).tar.gz
+	git clone $(PY3PLYURL)
 	(cd $(PY3PLY); \
 	PYTHONPATH=$(PY3CIFRW_PREFIX)/lib/python:$(PY3CIFRW_PREFIX)/lib64/python; export PYTHONPATH; \
 	mkdir -p $(PY3CIFRW_PREFIX)/lib/python/site-packages; \

--- a/Makefile_DIALS
+++ b/Makefile_DIALS
@@ -327,7 +327,7 @@ ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 # Definitions to get versions of python3 PyCifRW and PLY
 #
 PY3CIFRW ?= PyCifRW-4.3_rev_19Jun21
-PY3PLY = ply-3.11
+PY3PLY = ply
 PY3CIFRWFLAG = -DCBF_USE_PYCIFRW
 PY3CIFRW_PREFIX ?= $(HOME)/.local
 endif
@@ -694,7 +694,7 @@ PY2PLYURL      = http://www.dabeaz.com/ply/$(PY2PLY).tar.gz
 endif
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 PY3CIFRWURL     = http://downloads.sf.net/cbflib/$(PY3CIFRW).tar.gz
-PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
+PY3PLYURL       = https://github.com/dabeaz/ply.git
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
@@ -1379,10 +1379,7 @@ build_py3ply:   $(M4)/Makefile.m4
 	touch build_py3ply
 $(PY3PLY):      build_py3ply
 	-rm -rf $(PY3PLY)
-	-rm -rf $(PY3PLY).tar.gz
-	$(DOWNLOAD) $(PY3PLYURL)
-	tar -xvf $(PY3PLY).tar.gz
-	-rm $(PY3PLY).tar.gz
+	git clone $(PY3PLYURL)
 	(cd $(PY3PLY); \
 	PYTHONPATH=$(PY3CIFRW_PREFIX)/lib/python:$(PY3CIFRW_PREFIX)/lib64/python; export PYTHONPATH; \
 	mkdir -p $(PY3CIFRW_PREFIX)/lib/python/site-packages; \

--- a/Makefile_LINUX
+++ b/Makefile_LINUX
@@ -329,7 +329,7 @@ ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 # Definitions to get versions of python3 PyCifRW and PLY
 #
 PY3CIFRW ?= PyCifRW-4.3_rev_19Jun21
-PY3PLY = ply-3.11
+PY3PLY = ply
 PY3CIFRWFLAG = -DCBF_USE_PYCIFRW
 PY3CIFRW_PREFIX ?= $(HOME)/.local
 endif
@@ -761,7 +761,7 @@ PY2PLYURL      = http://www.dabeaz.com/ply/$(PY2PLY).tar.gz
 endif
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 PY3CIFRWURL     = http://downloads.sf.net/cbflib/$(PY3CIFRW).tar.gz
-PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
+PY3PLYURL       = https://github.com/dabeaz/ply.git
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
@@ -1509,10 +1509,7 @@ build_py3ply:   $(M4)/Makefile.m4
 	touch build_py3ply
 $(PY3PLY):      build_py3ply
 	-rm -rf $(PY3PLY)
-	-rm -rf $(PY3PLY).tar.gz
-	$(DOWNLOAD) $(PY3PLYURL)
-	tar -xvf $(PY3PLY).tar.gz
-	-rm $(PY3PLY).tar.gz
+	git clone $(PY3PLYURL)
 	(cd $(PY3PLY); \
 	PYTHONPATH=$(PY3CIFRW_PREFIX)/lib/python:$(PY3CIFRW_PREFIX)/lib64/python; export PYTHONPATH; \
 	mkdir -p $(PY3CIFRW_PREFIX)/lib/python/site-packages; \

--- a/Makefile_MINGW
+++ b/Makefile_MINGW
@@ -329,7 +329,7 @@ ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 # Definitions to get versions of python3 PyCifRW and PLY
 #
 PY3CIFRW ?= PyCifRW-4.3_rev_19Jun21
-PY3PLY = ply-3.11
+PY3PLY = ply
 PY3CIFRWFLAG = -DCBF_USE_PYCIFRW
 PY3CIFRW_PREFIX ?= $(HOME)/.local
 endif
@@ -775,7 +775,7 @@ PY2PLYURL      = http://www.dabeaz.com/ply/$(PY2PLY).tar.gz
 endif
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 PY3CIFRWURL     = http://downloads.sf.net/cbflib/$(PY3CIFRW).tar.gz
-PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
+PY3PLYURL       = https://github.com/dabeaz/ply.git
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
@@ -1523,10 +1523,7 @@ build_py3ply:   $(M4)/Makefile.m4
 	touch build_py3ply
 $(PY3PLY):      build_py3ply
 	-rm -rf $(PY3PLY)
-	-rm -rf $(PY3PLY).tar.gz
-	$(DOWNLOAD) $(PY3PLYURL)
-	tar -xvf $(PY3PLY).tar.gz
-	-rm $(PY3PLY).tar.gz
+	git clone $(PY3PLYURL)
 	(cd $(PY3PLY); \
 	PYTHONPATH=$(PY3CIFRW_PREFIX)/lib/python:$(PY3CIFRW_PREFIX)/lib64/python; export PYTHONPATH; \
 	mkdir -p $(PY3CIFRW_PREFIX)/lib/python/site-packages; \

--- a/Makefile_MSYS2
+++ b/Makefile_MSYS2
@@ -328,7 +328,7 @@ ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 # Definitions to get versions of python3 PyCifRW and PLY
 #
 PY3CIFRW ?= PyCifRW-4.3_rev_19Jun21
-PY3PLY = ply-3.11
+PY3PLY = ply
 PY3CIFRWFLAG = -DCBF_USE_PYCIFRW
 PY3CIFRW_PREFIX ?= $(HOME)/.local
 endif
@@ -760,7 +760,7 @@ PY2PLYURL      = http://www.dabeaz.com/ply/$(PY2PLY).tar.gz
 endif
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 PY3CIFRWURL     = http://downloads.sf.net/cbflib/$(PY3CIFRW).tar.gz
-PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
+PY3PLYURL       = https://github.com/dabeaz/ply.git
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
@@ -1508,13 +1508,7 @@ build_py3ply:   $(M4)/Makefile.m4
 	touch build_py3ply
 $(PY3PLY):      build_py3ply
 	-rm -rf $(PY3PLY)
-	-rm -rf $(PY3PLY).tar.gz
-	$(DOWNLOAD) $(PY3PLYURL)
-	tar -xvf $(PY3PLY).tar.gz
-	-rm $(PY3PLY).tar.gz
-	(cd $(PY3PLY); \
-	PYTHONPATH=$(PY3CIFRW_PREFIX)/lib/python:$(PY3CIFRW_PREFIX)/lib64/python; export PYTHONPATH; \
-	mkdir -p $(PY3CIFRW_PREFIX)/lib/python/site-packages; \
+	git clone $(PY3PLY); \
 	mkdir -p $(PY3CIFRW_PREFIX)/lib64/python/site-packages; \
 	$(PYTHON3) -m build --config-setting=install -C--prefix= -C--home=$(PY3CIFRW_PREFIX) )
 endif

--- a/Makefile_OSX
+++ b/Makefile_OSX
@@ -329,7 +329,7 @@ ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 # Definitions to get versions of python3 PyCifRW and PLY
 #
 PY3CIFRW ?= PyCifRW-4.3_rev_19Jun21
-PY3PLY = ply-3.11
+PY3PLY = ply
 PY3CIFRWFLAG = -DCBF_USE_PYCIFRW
 PY3CIFRW_PREFIX ?= $(HOME)/.local
 endif
@@ -759,7 +759,7 @@ PY2PLYURL      = http://www.dabeaz.com/ply/$(PY2PLY).tar.gz
 endif
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 PY3CIFRWURL     = http://downloads.sf.net/cbflib/$(PY3CIFRW).tar.gz
-PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
+PY3PLYURL       = https://github.com/dabeaz/ply.git
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
@@ -1507,10 +1507,7 @@ build_py3ply:   $(M4)/Makefile.m4
 	touch build_py3ply
 $(PY3PLY):      build_py3ply
 	-rm -rf $(PY3PLY)
-	-rm -rf $(PY3PLY).tar.gz
-	$(DOWNLOAD) $(PY3PLYURL)
-	tar -xvf $(PY3PLY).tar.gz
-	-rm $(PY3PLY).tar.gz
+	git clone $(PY3PLYURL)
 	(cd $(PY3PLY); \
 	PYTHONPATH=$(PY3CIFRW_PREFIX)/lib/python:$(PY3CIFRW_PREFIX)/lib64/python; export PYTHONPATH; \
 	mkdir -p $(PY3CIFRW_PREFIX)/lib/python/site-packages; \

--- a/m4/Makefile.m4
+++ b/m4/Makefile.m4
@@ -336,7 +336,7 @@ ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 # Definitions to get versions of python3 PyCifRW and PLY
 #
 PY3CIFRW ?= PyCifRW-4.3_rev_19Jun21
-PY3PLY = ply-3.11
+PY3PLY = ply
 PY3CIFRWFLAG = -DCBF_USE_PYCIFRW
 PY3CIFRW_PREFIX ?= $(HOME)/.local
 endif
@@ -1134,7 +1134,7 @@ PY2PLYURL      = http://www.dabeaz.com/ply/$(PY2PLY).tar.gz
 endif
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 PY3CIFRWURL     = http://downloads.sf.net/cbflib/$(PY3CIFRW).tar.gz
-PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
+PY3PLYURL       = https://github.com/dabeaz/ply.git
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
@@ -1882,10 +1882,7 @@ build_py3ply:   $(M4)/Makefile.m4
 	touch build_py3ply
 $(PY3PLY):      build_py3ply
 	-rm -rf $(PY3PLY)
-	-rm -rf $(PY3PLY).tar.gz
-	$(DOWNLOAD) $(PY3PLYURL)
-	tar -xvf $(PY3PLY).tar.gz
-	-rm $(PY3PLY).tar.gz
+	git clone $(PY3PLYURL)
 	(cd $(PY3PLY); \
 	PYTHONPATH=$(PY3CIFRW_PREFIX)/lib/python:$(PY3CIFRW_PREFIX)/lib64/python; export PYTHONPATH; \
 	mkdir -p $(PY3CIFRW_PREFIX)/lib/python/site-packages; \


### PR DESCRIPTION
The setuptools install of ply is failing due to https://github.com/pypa/setuptools/pull/4870. Ply is no longer released, but we can still clone it from github. Note this PR does not touch PY2PLY because I don't have a test case for it.