### PR TITLE
Two separate buffer overruns

### DIFF
--- a/src/cbf_binary.c
+++ b/src/cbf_binary.c
@@ -308,7 +308,7 @@ int cbf_get_bintext (const cbf_node  *column, unsigned int row,
 
   char digest_text [25];
   
-  char byteorder_text [14];
+  char byteorder_text [15];
 
   const char *text;
 

--- a/src/cbf_hdf5.c
+++ b/src/cbf_hdf5.c
@@ -26857,6 +26857,7 @@ static int process_DiffrnScanAxisCache(cbf_node * const category,
                                             cbf_debug_print2("error: %s\n",cbf_strerror(CBF_ALLOC));
                                             error |= CBF_ALLOC;
                                         } else {
+                                            axes = newAxes;
                                             axes[nAxes-1] = axis;
                                         }
                                     }
@@ -26986,7 +26987,7 @@ static int process_DiffrnScanAxisCache(cbf_node * const category,
                                 /* write the offset */
                                 double offset[3] = {0.,0.,0.};
                                 const hsize_t dim[] = {3};
-                                double buf[] = {0};
+                                double buf[3] = {0.,0.,0.};
                                 if (3==axis_settings.nOffset) {
                                     CBF_CALL(cbf_apply_matrix(key->matrix,axis_settings.offset,offset));
                                 }


### PR DESCRIPTION
These were previously found to crash the current `19-1.h5` test,

`cbf2nexus -c zlib --list -o i19-1.h5 "${CBF_DATA_INPUT}/1191_00005.cbf"`

on MSVC.  The omission to assign `axes` appears asymptomatic, insofar as the tests are concerned.  Found with ASan.