### PR TITLE
Synchronize Fortran to Makefile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1032,14 +1032,12 @@ if(CBF_ENABLE_FORTRAN)
   add_executable(test_fcb_read_image
     "${CMAKE_CURRENT_BINARY_DIR}/src/test_fcb_read_image.f90")
   target_link_libraries(test_fcb_read_image
-    fcb
-    hdf5)
+    fcb)
 
   add_executable(test_xds_binary
     "${CMAKE_CURRENT_BINARY_DIR}/src/test_xds_binary.f90")
   target_link_libraries(test_xds_binary
-    fcb
-    hdf5)
+    fcb)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,7 +363,6 @@ endmacro(CBF_REQUIRE_DIRECTORY)
 #
 set(CBF__SRC       "${CBFlib_SOURCE_DIR}/src" )
 set(CBF__INCLUDE   "${CBFlib_SOURCE_DIR}/include" )
-set(CBF__M4        "${CBFlib_SOURCE_DIR}/m4" )
 set(CBF__DOC       "${CBFlib_SOURCE_DIR}/doc" )
 set(CBF__EXAMPLES  "${CBFlib_SOURCE_DIR}/examples" )
 set(CBF__EXTERNAL_PACKAGES 
@@ -375,8 +374,6 @@ set(CBF__DECTRIS_EXAMPLES
 #
 # Directories on the build side
 #
-set(CBF__BLDSRC    "${CBFlib_BINARY_DIR}/src" )
-set(CBF__BLDEXMP   "${CBFlib_BINARY_DIR}/src" )
 set(CBF__BIN       "${CBFlib_BINARY_DIR}/bin" )
 set(CBF__LIB       "${CBFlib_BINARY_DIR}/lib" )
 set(CBF__BIN_INCLUDE "${CBFlib_BINARY_DIR}/include" )
@@ -384,8 +381,6 @@ set(CBF__SHARE     "${CBFlib_BINARY_DIR}/share" )
 set(CBF__EXT_PKG   "${CBFlib_BINARY_DIR}/external_packages" )
 set(CBF__DATA      "${CBFlib_BINARY_DIR}/data_files" )
 
-CBF_REQUIRE_DIRECTORY(${CBF__BLDSRC})
-CBF_REQUIRE_DIRECTORY(${CBF__BLDEXMP})
 CBF_REQUIRE_DIRECTORY(${CBF__BIN})
 CBF_REQUIRE_DIRECTORY(${CBF__LIB})
 CBF_REQUIRE_DIRECTORY(${CBF__BIN_INCLUDE})
@@ -825,21 +820,45 @@ set_target_properties(img PROPERTIES LINKER_LANGUAGE C)
 
 
 #
-# Build Fortran library and example sources and the fcb library.
+# Build all Fortran sources and the fcb library.
 if(CBF_ENABLE_FORTRAN)
   find_program(M4 m4 REQUIRED)
   set(M4FLAGS "-Dfcb_bytes_in_rec=4096" CACHE STRING
     "Flags used by the M4 macro processor during Fortran build")
   mark_as_advanced(M4FLAGS)
 
+  set(f90_sources_m4
+    "${CMAKE_CURRENT_SOURCE_DIR}/m4/fcb_exit_binary.m4"
+    "${CMAKE_CURRENT_SOURCE_DIR}/m4/fcb_next_binary.m4"
+    "${CMAKE_CURRENT_SOURCE_DIR}/m4/fcb_open_cifin.m4"
+    "${CMAKE_CURRENT_SOURCE_DIR}/m4/fcb_packed.m4"
+    "${CMAKE_CURRENT_SOURCE_DIR}/m4/fcb_read_bits.m4"
+    "${CMAKE_CURRENT_SOURCE_DIR}/m4/fcb_read_image.m4"
+    "${CMAKE_CURRENT_SOURCE_DIR}/m4/fcb_read_xds_i2.m4"
+    "${CMAKE_CURRENT_SOURCE_DIR}/m4/test_fcb_read_image.m4"
+    "${CMAKE_CURRENT_SOURCE_DIR}/m4/test_xds_binary.m4")
+
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src")
+  foreach(f90srcm4 IN LISTS f90_sources_m4)
+    get_filename_component(filename "${f90srcm4}" NAME_WE)
+    set(f90bldsrc "${CMAKE_CURRENT_BINARY_DIR}/src/${filename}.f90")
+    add_custom_command(
+      OUTPUT "${f90bldsrc}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/m4"
+      COMMAND ${M4} -P ${M4FLAGS} "${f90srcm4}" > "${f90bldsrc}"
+      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/m4/fcblib_defines.m4"
+              "${f90srcm4}"
+      COMMENT "Generating ${f90bldsrc}")
+  endforeach()
+
   set(CBF_F90_BUILT_SOURCES
-    "${CBF__BLDSRC}/fcb_exit_binary.f90"
-    "${CBF__BLDSRC}/fcb_next_binary.f90"
-    "${CBF__BLDSRC}/fcb_open_cifin.f90"
-    "${CBF__BLDSRC}/fcb_packed.f90"
-    "${CBF__BLDSRC}/fcb_read_bits.f90"
-    "${CBF__BLDSRC}/fcb_read_image.f90"
-    "${CBF__BLDSRC}/fcb_read_xds_i2.f90")
+    "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_exit_binary.f90"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_next_binary.f90"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_open_cifin.f90"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_packed.f90"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_read_bits.f90"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_read_image.f90"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_read_xds_i2.f90")
 
   set(CBF_F90_SOURCES
     "${CBF__SRC}/fcb_atol_wcnt.f90"
@@ -848,34 +867,6 @@ if(CBF_ENABLE_FORTRAN)
     "${CBF__SRC}/fcb_read_byte.f90"
     "${CBF__SRC}/fcb_read_line.f90"
     "${CBF__SRC}/fcb_skip_whitespace.f90")
-
-  set(CBF_M4_FCB_DEFINES
-    "${CBF__M4}/fcblib_defines.m4")
-
-  set(CBF_M4_FCB_FILES
-    "${CBF__M4}/fcb_exit_binary.m4"
-    "${CBF__M4}/fcb_next_binary.m4"
-    "${CBF__M4}/fcb_open_cifin.m4"
-    "${CBF__M4}/fcb_packed.m4"
-    "${CBF__M4}/fcb_read_bits.m4"
-    "${CBF__M4}/fcb_read_image.m4"
-    "${CBF__M4}/fcb_read_xds_i2.m4")
-
-  set(CBF_M4_F90_EXAMPLES
-    "${CBF__M4}/test_fcb_read_image.m4"
-    "${CBF__M4}/test_xds_binary.m4")
-
-  foreach(f90src IN LISTS CBF_F90_BUILT_SOURCES)
-    get_filename_component(filename "${f90src}" NAME_WE )
-    set(f90bldsrc "${CBF__BLDSRC}/${filename}.f90")
-    set(f90srcm4 "${CBF__M4}/${filename}.m4")
-    add_custom_command(
-      OUTPUT "${f90bldsrc}"
-      WORKING_DIRECTORY "${CBF__M4}"
-      COMMAND ${M4} -P "${M4FLAGS}" "${f90srcm4}" > "${f90bldsrc}"
-      DEPENDS ${CBF_M4_FCB_DEFINES} ${f90srcm4}
-      COMMENT "Generating ${f90bldsrc}")
-  endforeach(f90src)
 
   add_library(fcb ${CBF_F90_BUILT_SOURCES};${CBF_F90_SOURCES})
   set_target_properties(fcb PROPERTIES OUTPUT_NAME "fcb")
@@ -1029,25 +1020,14 @@ target_link_libraries(testreals
 #  F90 examples
 #
 if(CBF_ENABLE_FORTRAN)
-  add_custom_command(OUTPUT "${CBF__BLDEXMP}/test_fcb_read_image.f90"
-    WORKING_DIRECTORY "${CBF__M4}"
-    COMMAND ${M4} -P "${M4FLAGS}" "${CBF__M4}/test_fcb_read_image.m4" > "${CBF__BLDEXMP}/test_fcb_read_image.f90"
-    DEPENDS ${CBF_M4_FCB_DEFINES} "${CBF__M4}/test_fcb_read_image.m4"
-    COMMENT "Generating ${test_fcb_read_image.f90}")
-  add_custom_command(OUTPUT "${CBF__BLDEXMP}/test_xds_binary.f90"
-    WORKING_DIRECTORY "${CBF__M4}"
-    COMMAND ${M4} -P "${M4FLAGS}" "${CBF__M4}/test_xds_binary.m4" > "${CBF__BLDEXMP}/test_xds_binary.f90"
-    DEPENDS ${CBF_M4_FCB_DEFINES} "${CBF__M4}/test_xds_binary.m4"
-    COMMENT "Generating ${test_xds_binary.f90}")
-
   add_executable(test_fcb_read_image
-    "${CBF__BLDEXMP}/test_fcb_read_image.f90")
+    "${CMAKE_CURRENT_BINARY_DIR}/src/test_fcb_read_image.f90")
   target_link_libraries(test_fcb_read_image
     fcb
     hdf5)
 
   add_executable(test_xds_binary
-    "${CBF__BLDEXMP}/test_xds_binary.f90")
+    "${CMAKE_CURRENT_BINARY_DIR}/src/test_xds_binary.f90")
   target_link_libraries(test_xds_binary
     fcb
     hdf5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -820,7 +820,8 @@ set_target_properties(img PROPERTIES LINKER_LANGUAGE C)
 
 
 #
-# Build all Fortran sources and the fcb library.
+# Build all Fortran sources and libraries.  The f90cbf library is not
+# installed.
 if(CBF_ENABLE_FORTRAN)
   find_program(M4 m4 REQUIRED)
   set(M4FLAGS "-Dfcb_bytes_in_rec=4096" CACHE STRING
@@ -851,26 +852,32 @@ if(CBF_ENABLE_FORTRAN)
       COMMENT "Generating ${f90bldsrc}")
   endforeach()
 
-  set(CBF_F90_BUILT_SOURCES
+  add_library(fcb
     "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_exit_binary.f90"
     "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_next_binary.f90"
     "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_open_cifin.f90"
     "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_packed.f90"
     "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_read_bits.f90"
     "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_read_image.f90"
-    "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_read_xds_i2.f90")
-
-  set(CBF_F90_SOURCES
+    "${CMAKE_CURRENT_BINARY_DIR}/src/fcb_read_xds_i2.f90"
     "${CBF__SRC}/fcb_atol_wcnt.f90"
     "${CBF__SRC}/fcb_ci_strncmparr.f90"
     "${CBF__SRC}/fcb_nblen_array.f90"
     "${CBF__SRC}/fcb_read_byte.f90"
     "${CBF__SRC}/fcb_read_line.f90"
     "${CBF__SRC}/fcb_skip_whitespace.f90")
-
-  add_library(fcb ${CBF_F90_BUILT_SOURCES};${CBF_F90_SOURCES})
   set_target_properties(fcb PROPERTIES OUTPUT_NAME "fcb")
   set_target_properties(fcb PROPERTIES LINKER_LANGUAGE C)
+  install(TARGETS fcb DESTINATION lib)
+
+
+  # Use the pre-generated SWIG wrapper, because current SWIG does not
+  # support Fortran.
+  add_library(f90cbf
+    "${CMAKE_CURRENT_SOURCE_DIR}/f90cbf/f90cbf.f90"
+    "${CMAKE_CURRENT_SOURCE_DIR}/f90cbf/f90cbf_wrap.c")
+  target_link_libraries(f90cbf
+    cbf)
 endif()
 
 
@@ -913,6 +920,9 @@ add_executable(cbf2adscimg
 target_link_libraries(cbf2adscimg
   cbf
   "${libm}")
+
+add_executable(convert_f90_swig_wrap
+  "${CBF__EXAMPLES}/convert_f90_swig_wrap.cpp")
 
 add_executable(convert_image
   "${CBF__EXAMPLES}/convert_image.c")
@@ -1017,8 +1027,7 @@ target_link_libraries(testreals
 
 
 #
-#  F90 examples
-#
+# F90 examples.  Only for testing, not installed.
 if(CBF_ENABLE_FORTRAN)
   add_executable(test_fcb_read_image
     "${CMAKE_CURRENT_BINARY_DIR}/src/test_fcb_read_image.f90")
@@ -1054,10 +1063,6 @@ install (TARGETS sauter_test DESTINATION bin)
 install (TARGETS sequence_match DESTINATION bin)
 install (TARGETS tiff2cbf DESTINATION bin)
 install(TARGETS cbf DESTINATION lib)
-
-if(CBF_ENABLE_FORTRAN)
-  install(TARGETS fcb DESTINATION lib)
-endif()
 
 install(TARGETS img DESTINATION lib)
 install (DIRECTORY ${CBF__INCLUDE}/ DESTINATION include/cbflib FILES_MATCHING PATTERN "*.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,9 +295,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 
-set(CBF_F90FLAGS_ENV $ENV{F90FLAGS})
-set(CBF_M4FLAGS_ENV $ENV{M4FLAGS})
-
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 option(CBF_ENABLE_FORTRAN "Enable Fortran 90" ON)
@@ -319,24 +316,6 @@ set (CBF_CMAKE_DEBUG "ON")
 #
 #  User setable parameters
 #
-
-if (CBF_M4FLAGS_ENV)
-  set(CBF_M4FLAGS ${CBF_M4FLAGS_ENV})
-else (CBF_M4FLAGS_ENV)
-  set(CBF_M4FLAGS "-Dfcb_bytes_in_rec=4096")
-endif (CBF_M4FLAGS_ENV)
-
-if(CBF_ENABLE_FORTRAN)
-
-if (CBF_F90FLAGS_ENV)
-  set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} ${CBF_F90FLAGS_ENV}")
-  set(CMAKE_Fortran_FLAGS_DEBUG   "${CMAKE_Fortran_FLAGS_DEBUG}   ${CBF_F90FLAGS_ENV}")
-else (CBF_F90FLAGS_ENV)
-  set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -fno-range-check")
-  set(CMAKE_Fortran_FLAGS_DEBUG   "${CMAKE_Fortran_FLAGS_DEBUG}   -fno-range-check")
-endif (CBF_F90FLAGS_ENV)
-
-endif()
 
 # make sure that the default is a RELEASE
 if (NOT CMAKE_BUILD_TYPE)
@@ -711,30 +690,6 @@ set(
     ${CBF__SRC}/img.c
 )
 
-if(CBF_ENABLE_FORTRAN)
-
-set(
-	CBF_F90_BUILT_SOURCES 
-			${CBF__BLDSRC}/fcb_exit_binary.f90
-			${CBF__BLDSRC}/fcb_next_binary.f90
-			${CBF__BLDSRC}/fcb_open_cifin.f90
-			${CBF__BLDSRC}/fcb_packed.f90
-			${CBF__BLDSRC}/fcb_read_bits.f90
-			${CBF__BLDSRC}/fcb_read_image.f90
-	${CBF__BLDSRC}/fcb_read_xds_i2.f90
-)
-            
-set(
-	CBF_F90_SOURCES
-	${CBF__SRC}/fcb_atol_wcnt.f90
-			${CBF__SRC}/fcb_ci_strncmparr.f90
-			${CBF__SRC}/fcb_nblen_array.f90
-			${CBF__SRC}/fcb_read_byte.f90
-			${CBF__SRC}/fcb_read_line.f90
-	${CBF__SRC}/fcb_skip_whitespace.f90
-)
-
-endif()
 
 # use, i.e. don't skip the full RPATH for the build tree
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
@@ -799,38 +754,6 @@ set(
 if(CBF_ENABLE_ULP)
   list(APPEND CBF_HEADERS
     "${CBF__INCLUDE}/cbf_ulp.h")
-endif()
-
-
-if(CBF_ENABLE_FORTRAN)
-
-#
-# m4 FCB library macro files
-#
-set(
-	CBF_M4_FCB_DEFINES
-	${CBF__M4}/fcblib_defines.m4
-)
-
-set(
-	CBF_M4_FCB_FILES 
-			${CBF__M4}/fcb_exit_binary.m4
-			${CBF__M4}/fcb_next_binary.m4
-			${CBF__M4}/fcb_open_cifin.m4
-			${CBF__M4}/fcb_packed.m4
-			${CBF__M4}/fcb_read_bits.m4
-			${CBF__M4}/fcb_read_image.m4
-	${CBF__M4}/fcb_read_xds_i2.m4
-)
-#
-# m4 F90 examples macro files
-#
-set(
-	CBF_M4_F90_EXAMPLES
-            ${CBF__M4}/test_fcb_read_image.m4
-	${CBF__M4}/test_xds_binary.m4
-)
-
 endif()
 
 
@@ -901,32 +824,62 @@ set_target_properties(img PROPERTIES OUTPUT_NAME "img")
 set_target_properties(img PROPERTIES LINKER_LANGUAGE C)
 
 
+#
+# Build Fortran library and example sources and the fcb library.
 if(CBF_ENABLE_FORTRAN)
+  find_program(M4 m4 REQUIRED)
+  set(M4FLAGS "-Dfcb_bytes_in_rec=4096" CACHE STRING
+    "Flags used by the M4 macro processor during Fortran build")
+  mark_as_advanced(M4FLAGS)
 
-#
-# Build the f90 library sources
-#
-find_program(M4 m4)
-foreach(f90src IN LISTS CBF_F90_BUILT_SOURCES)
-  get_filename_component(filename "${f90src}" NAME_WE )
-  set(f90bldsrc "${CBF__BLDSRC}/${filename}.f90")
-  set(f90srcm4 "${CBF__M4}/${filename}.m4")
-	add_custom_command(
-		OUTPUT "${f90bldsrc}"
-    WORKING_DIRECTORY "${CBF__M4}"
-    COMMAND ${M4} -P "${CBF_M4FLAGS}" "${f90srcm4}" > "${f90bldsrc}"
-    DEPENDS ${CBF_M4_FCB_DEFINES} ${f90srcm4}
-		COMMENT "Generating ${f90bldsrc}"
-	)
-endforeach(f90src)
+  set(CBF_F90_BUILT_SOURCES
+    "${CBF__BLDSRC}/fcb_exit_binary.f90"
+    "${CBF__BLDSRC}/fcb_next_binary.f90"
+    "${CBF__BLDSRC}/fcb_open_cifin.f90"
+    "${CBF__BLDSRC}/fcb_packed.f90"
+    "${CBF__BLDSRC}/fcb_read_bits.f90"
+    "${CBF__BLDSRC}/fcb_read_image.f90"
+    "${CBF__BLDSRC}/fcb_read_xds_i2.f90")
 
+  set(CBF_F90_SOURCES
+    "${CBF__SRC}/fcb_atol_wcnt.f90"
+    "${CBF__SRC}/fcb_ci_strncmparr.f90"
+    "${CBF__SRC}/fcb_nblen_array.f90"
+    "${CBF__SRC}/fcb_read_byte.f90"
+    "${CBF__SRC}/fcb_read_line.f90"
+    "${CBF__SRC}/fcb_skip_whitespace.f90")
 
-#
-# Build the fcb libraries
-#
-add_library(fcb ${CBF_F90_BUILT_SOURCES};${CBF_F90_SOURCES})
-set_target_properties(fcb PROPERTIES OUTPUT_NAME "fcb")
-set_target_properties(fcb PROPERTIES LINKER_LANGUAGE C)
+  set(CBF_M4_FCB_DEFINES
+    "${CBF__M4}/fcblib_defines.m4")
+
+  set(CBF_M4_FCB_FILES
+    "${CBF__M4}/fcb_exit_binary.m4"
+    "${CBF__M4}/fcb_next_binary.m4"
+    "${CBF__M4}/fcb_open_cifin.m4"
+    "${CBF__M4}/fcb_packed.m4"
+    "${CBF__M4}/fcb_read_bits.m4"
+    "${CBF__M4}/fcb_read_image.m4"
+    "${CBF__M4}/fcb_read_xds_i2.m4")
+
+  set(CBF_M4_F90_EXAMPLES
+    "${CBF__M4}/test_fcb_read_image.m4"
+    "${CBF__M4}/test_xds_binary.m4")
+
+  foreach(f90src IN LISTS CBF_F90_BUILT_SOURCES)
+    get_filename_component(filename "${f90src}" NAME_WE )
+    set(f90bldsrc "${CBF__BLDSRC}/${filename}.f90")
+    set(f90srcm4 "${CBF__M4}/${filename}.m4")
+    add_custom_command(
+      OUTPUT "${f90bldsrc}"
+      WORKING_DIRECTORY "${CBF__M4}"
+      COMMAND ${M4} -P "${M4FLAGS}" "${f90srcm4}" > "${f90bldsrc}"
+      DEPENDS ${CBF_M4_FCB_DEFINES} ${f90srcm4}
+      COMMENT "Generating ${f90bldsrc}")
+  endforeach(f90src)
+
+  add_library(fcb ${CBF_F90_BUILT_SOURCES};${CBF_F90_SOURCES})
+  set_target_properties(fcb PROPERTIES OUTPUT_NAME "fcb")
+  set_target_properties(fcb PROPERTIES LINKER_LANGUAGE C)
 endif()
 
 
@@ -1078,12 +1031,12 @@ target_link_libraries(testreals
 if(CBF_ENABLE_FORTRAN)
   add_custom_command(OUTPUT "${CBF__BLDEXMP}/test_fcb_read_image.f90"
     WORKING_DIRECTORY "${CBF__M4}"
-    COMMAND ${M4} -P "${CBF_M4FLAGS}" "${CBF__M4}/test_fcb_read_image.m4" > "${CBF__BLDEXMP}/test_fcb_read_image.f90"
+    COMMAND ${M4} -P "${M4FLAGS}" "${CBF__M4}/test_fcb_read_image.m4" > "${CBF__BLDEXMP}/test_fcb_read_image.f90"
     DEPENDS ${CBF_M4_FCB_DEFINES} "${CBF__M4}/test_fcb_read_image.m4"
     COMMENT "Generating ${test_fcb_read_image.f90}")
   add_custom_command(OUTPUT "${CBF__BLDEXMP}/test_xds_binary.f90"
     WORKING_DIRECTORY "${CBF__M4}"
-    COMMAND ${M4} -P "${CBF_M4FLAGS}" "${CBF__M4}/test_xds_binary.m4" > "${CBF__BLDEXMP}/test_xds_binary.f90"
+    COMMAND ${M4} -P "${M4FLAGS}" "${CBF__M4}/test_xds_binary.m4" > "${CBF__BLDEXMP}/test_xds_binary.f90"
     DEPENDS ${CBF_M4_FCB_DEFINES} "${CBF__M4}/test_xds_binary.m4"
     COMMENT "Generating ${test_xds_binary.f90}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2218,3 +2218,119 @@ add_test(NAME dectris-cmp
 set_tests_properties(dectris-cmp PROPERTIES
   FIXTURES_REQUIRED dectris
   REQUIRED_FILES "${CBFlib_SOURCE_DIR}/templates/cbf_test_orig.out")
+
+
+#
+# Fortran tests
+#
+# test_fcb_read_image and test_xds_binary expect the name of the input
+# file on stdin and write to stdout.  The input file cannot have any
+# directory components.
+if(CBF_ENABLE_FORTRAN)
+  #
+  # xds_binary-flat
+  add_test(NAME xds_binary-flat
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:test_xds_binary>"
+      "-Dinput=testflatin.cbf"
+      "-Doutput-file=${CBF__DATA}/test_xds_bin_testflatout.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake"
+    WORKING_DIRECTORY "${data_input}")
+  set_tests_properties(xds_binary-flat PROPERTIES
+    FIXTURES_SETUP xds_binary-flat
+    REQUIRED_FILES "${data_input}/testflatin.cbf")
+
+  add_test(NAME xds_binary-flat-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/test_xds_bin_testflatout.out")
+  set_tests_properties(xds_binary-flat-cleanup PROPERTIES
+    FIXTURES_CLEANUP xds_binary-flat)
+
+  add_test(NAME xds_binary-flat-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/test_xds_bin_testflatout_orig.out"
+      "${CBF__DATA}/test_xds_bin_testflatout.out")
+  set_tests_properties(xds_binary-flat-cmp PROPERTIES
+    FIXTURES_REQUIRED xds_binary-flat
+    REQUIRED_FILES "${data_output}/test_xds_bin_testflatout_orig.out")
+
+
+  #
+  # xds_binary-flatpacked
+  add_test(NAME xds_binary-flatpacked
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:test_xds_binary>"
+      "-Dinput=testflatpackedin.cbf"
+      "-Doutput-file=${CBF__DATA}/test_xds_bin_testflatpackedout.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake"
+    WORKING_DIRECTORY "${data_input}")
+  set_tests_properties(xds_binary-flatpacked PROPERTIES
+    FIXTURES_SETUP xds_binary-flatpacked
+    REQUIRED_FILES "${data_input}/testflatpackedin.cbf")
+
+  add_test(NAME xds_binary-flatpacked-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/test_xds_bin_testflatpackedout.out")
+  set_tests_properties(xds_binary-flatpacked-cleanup PROPERTIES
+    FIXTURES_CLEANUP xds_binary-flatpacked)
+
+  add_test(NAME xds_binary-flatpacked-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/test_xds_bin_testflatpackedout_orig.out"
+      "${CBF__DATA}/test_xds_bin_testflatpackedout.out")
+  set_tests_properties(xds_binary-flatpacked-cmp PROPERTIES
+    FIXTURES_REQUIRED xds_binary-flatpacked
+    REQUIRED_FILES "${data_output}/test_xds_bin_testflatpackedout_orig.out")
+
+
+  #
+  # fcb_read_image-flat
+  add_test(NAME fcb_read_image-flat
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:test_fcb_read_image>"
+      "-Dinput=testflatin.cbf"
+      "-Doutput-file=${CBF__DATA}/test_fcb_read_testflatout.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake"
+    WORKING_DIRECTORY "${data_input}")
+  set_tests_properties(fcb_read_image-flat PROPERTIES
+    FIXTURES_SETUP fcb_read_image-flat
+    REQUIRED_FILES "${data_input}/testflatin.cbf")
+
+  add_test(NAME fcb_read_image-flat-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/test_fcb_read_testflatout.out")
+  set_tests_properties(fcb_read_image-flat-cleanup PROPERTIES
+    FIXTURES_CLEANUP fcb_read_image-flat)
+
+  add_test(NAME fcb_read_image-flat-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/test_fcb_read_testflatout_orig.out"
+      "${CBF__DATA}/test_fcb_read_testflatout.out")
+  set_tests_properties(fcb_read_image-flat-cmp PROPERTIES
+    FIXTURES_REQUIRED fcb_read_image-flat
+    REQUIRED_FILES "${data_output}/test_fcb_read_testflatout_orig.out")
+
+
+  #
+  # fcb_read_image-flatpacked
+  add_test(NAME fcb_read_image-flatpacked
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:test_fcb_read_image>"
+      "-Dinput=testflatpackedin.cbf"
+      "-Doutput-file=${CBF__DATA}/test_fcb_read_testflatpackedout.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake"
+    WORKING_DIRECTORY "${data_input}")
+  set_tests_properties(fcb_read_image-flatpacked PROPERTIES
+    FIXTURES_SETUP fcb_read_image-flatpacked
+    REQUIRED_FILES "${data_input}/testflatpackedin.cbf")
+
+  add_test(NAME fcb_read_image-flatpacked-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/test_fcb_read_testflatpackedout.out")
+  set_tests_properties(fcb_read_image-flatpacked-cleanup PROPERTIES
+    FIXTURES_CLEANUP fcb_read_image-flatpacked)
+
+  add_test(NAME fcb_read_image-flatpacked-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/test_fcb_read_testflatpackedout_orig.out"
+      "${CBF__DATA}/test_fcb_read_testflatpackedout.out")
+  set_tests_properties(fcb_read_image-flatpacked-cmp PROPERTIES
+    FIXTURES_REQUIRED fcb_read_image-flatpacked
+    REQUIRED_FILES "${data_output}/test_fcb_read_testflatpackedout_orig.out")
+endif()


### PR DESCRIPTION
Because stock SWIG does not support Fortran (and the state of [swig-fortran](https://github.com/swig-fortran/swig) is unclear), `CMakeLists.txt` relies on the pre-generated SWIG wrapper.  `convert_f90_swip_wrap` is built nonetheless.