### PR TITLE
Synchronize Python 3 to Makefile

### DIFF
--- a/.dev/docker/cmake_ctest.dockerfile
+++ b/.dev/docker/cmake_ctest.dockerfile
@@ -5,7 +5,7 @@ RUN mkdir /app
 COPY ./cbflib /app/cbflib
 
 RUN apt-get update && \
-  apt-get install -y build-essential git cmake default-jdk gfortran m4 swig
+  apt-get install -y build-essential git cmake default-jdk gfortran links m4 python3-dev swig
 
 RUN cd /app/cbflib && \
   cmake . && \

--- a/.dev/docker/cmake_ctest.dockerfile
+++ b/.dev/docker/cmake_ctest.dockerfile
@@ -5,7 +5,7 @@ RUN mkdir /app
 COPY ./cbflib /app/cbflib
 
 RUN apt-get update && \
-  apt-get install -y build-essential git cmake default-jdk gfortran links m4 python3-dev swig
+  apt-get install -y build-essential git cmake default-jdk gfortran links m4 python3-dev python3-numpy-dev swig
 
 RUN cd /app/cbflib && \
   cmake . && \

--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -21,10 +21,11 @@ jobs:
     - name: install extra dependencies
       run: |
         sudo apt-get update
+        sudo apt-get install -y python3-numpy-dev
     - name: build
       run: |
         cmake .
-        cmake --build . --parallel 4
+        cmake --build . --parallel `nproc`
     - name: test
       run: |
-        ctest --parallel 4
+        ctest --parallel `nproc`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,13 +314,14 @@ set (CBF_CMAKE_DEBUG "ON")
 
 
 #
-# Java bindings
+# Java and Python bindings
 #
-# The Java module can only be built when BUILD_SHARED_LIBS is set.  On
-# Debian, Java should only require openjdk-17-jdk-headless but AWT
-# requires openjdk-17-jdk?
+# The Java and Python modules can only be built when BUILD_SHARED_LIBS
+# is set.  On Debian, Java should only require openjdk-17-jdk-headless
+# but AWT requires openjdk-17-jdk?
 if(BUILD_SHARED_LIBS)
   option(CBF_ENABLE_JAVA "Enable Java" ON)
+  option(CBF_ENABLE_PYTHON "Enable Python" ON)
 endif()
 
 
@@ -834,8 +835,10 @@ include_directories(BEFORE SYSTEM
 # includes hdf5.h.
 add_library(cbf ${CBF_C_SOURCES})
 if(CBF_ENABLE_ULP)
-  target_compile_definitions(cbf PUBLIC CBF_USE_ULP)
-  target_sources(cbf PRIVATE "${CBF__SRC}/cbf_ulp.c")
+  target_compile_definitions(cbf
+    PUBLIC CBF_USE_ULP)
+  target_sources(cbf
+    PRIVATE "${CBF__SRC}/cbf_ulp.c")
 endif()
 
 set_target_properties(cbf PROPERTIES OUTPUT_NAME "cbf")
@@ -875,13 +878,14 @@ if(CBF_ENABLE_FORTRAN)
     "${CMAKE_CURRENT_SOURCE_DIR}/m4/test_fcb_read_image.m4"
     "${CMAKE_CURRENT_SOURCE_DIR}/m4/test_xds_binary.m4")
 
-  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src")
   foreach(f90srcm4 IN LISTS f90_sources_m4)
     get_filename_component(filename "${f90srcm4}" NAME_WE)
     set(f90bldsrc "${CMAKE_CURRENT_BINARY_DIR}/src/${filename}.f90")
     add_custom_command(
       OUTPUT "${f90bldsrc}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/m4"
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        "${CMAKE_CURRENT_BINARY_DIR}/src"
       COMMAND ${M4} -P ${M4FLAGS} "${f90srcm4}" > "${f90bldsrc}"
       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/m4/fcblib_defines.m4"
               "${f90srcm4}"
@@ -984,6 +988,72 @@ if(CBF_ENABLE_JAVA)
     VERSION "${PROJECT_VERSION}")
   add_dependencies(cbflib
     cbf_wrap)
+endif()
+
+
+#
+# Python bindings
+if(CBF_ENABLE_PYTHON)
+  # As per Makefile, want links (not lynx) to reduce the diffs against
+  # versioned CBFlib.txt.  Need SWIG 4.0.0 or later.  For Python 3,
+  # Makefile also adds "# coding=utf-8" to the top of pycbf.py.
+  find_program(BROWSER_DUMP_TOOL NAMES links lynx elinks)
+  find_package(Python COMPONENTS Development Interpreter REQUIRED)
+  find_package(SWIG COMPONENTS python REQUIRED)
+  include(UseSWIG)
+
+  add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/pycbf/CBFlib.txt"
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf"
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=${BROWSER_DUMP_TOOL};-dump;${CMAKE_CURRENT_SOURCE_DIR}/doc/CBFlib.html"
+      "-Doutput-file=${CMAKE_CURRENT_BINARY_DIR}/pycbf/CBFlib.txt"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/doc/CBFlib.html"
+    VERBATIM)
+
+
+  # Generate the SWIG interfaces from CBFlib.txt (so really no need to
+  # keep those under version control).
+  add_custom_command(
+    OUTPUT
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/cbfdetectorwrappers.i"
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/cbfgenericwrappers.i"
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/cbfgoniometerwrappers.i"
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/cbfhandlewrappers.i"
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/cbfpositionerwrappers.i"
+    COMMAND Python::Interpreter
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/make_pycbf.py"
+      -o "${CMAKE_CURRENT_BINARY_DIR}/pycbf"
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/CBFlib.txt"
+    DEPENDS
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/CBFlib.txt"
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/make_pycbf.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pycbf")
+
+  set_property(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf.i" PROPERTY
+    DEPENDS
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/cbfdetectorwrappers.i"
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/cbfgenericwrappers.i"
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/cbfgoniometerwrappers.i"
+      "${CMAKE_CURRENT_BINARY_DIR}/pycbf/cbfhandlewrappers.i")
+  swig_add_library(pycbf
+    SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf.i"
+    LANGUAGE Python
+    OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/pycbf")
+  set_target_properties(pycbf PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pycbf")
+  target_compile_definitions(pycbf
+    PRIVATE SWIG_PYTHON_STRICT_BYTE_CHAR)
+  target_link_libraries(pycbf
+    cbf
+    Python::Module)
+
+  install(
+    TARGETS pycbf
+    COMPONENT "Runtime"
+    DESTINATION "${Python_SITEARCH}")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,9 +337,14 @@ if (NOT CMAKE_BUILD_TYPE)
 endif (NOT CMAKE_BUILD_TYPE)
 
 
-# Check for missing functions: regcomp(3) is in POSIX.1-2001,
-# POSIX.1-2008.
+# Check for missing functions: fgetln(3) is in 4.4BSD; regcomp(3) is
+# in POSIX.1-2001, POSIX.1-2008.
 include(CheckSymbolExists)
+check_symbol_exists(fgetln "stdio.h" HAVE_FGETLN)
+if(HAVE_FGETLN)
+  add_compile_definitions("HAVE_FGETLN")
+endif()
+
 check_symbol_exists(regcomp "regex.h" HAVE_REGCOMP)
 
 
@@ -411,7 +416,6 @@ math(EXPR SOVERSION "${_current} - ${_age}")
 
 
 set(BIN       "${CBFlib_BINARY_DIR}/bin" CACHE STRING "")
-set(PYCBF     "${CBFlib_SOURCE_DIR}/pycbf" CACHE STRING "")
 set(EXAMPLES  "${CBFlib_SOURCE_DIR}/examples" CACHE STRING "" )
 set(DECTRIS_EXAMPLES "${EXAMPLES}/dectris_cbf_template_test" CACHE STRING "")
 set(GRAPHICS  "${CBFlib_SOURCE_DIR}/html_graphics" CACHE STRING "")
@@ -1114,6 +1118,15 @@ add_executable(makecbf
   "${CBF__EXAMPLES}/makecbf.c")
 target_link_libraries(makecbf
   cbf)
+
+add_executable(cbf_standardize_numbers
+  "${CBF__EXAMPLES}/cbf_standardize_numbers.c")
+target_link_libraries(cbf_standardize_numbers
+  cbf
+  "${libm}")
+if(NOT HAVE_FGETLN)
+  target_sources(cbf_standardize_numbers PRIVATE "${CBF__SRC}/fgetln.c")
+endif()
 
 add_executable(cbf_tail
   "${CBF__EXAMPLES}/cbf_tail.c")
@@ -2563,4 +2576,256 @@ if(CBF_ENABLE_JAVA)
       "${CBF__DATA}/testcbfj.txt")
   set_tests_properties(java-cmp PROPERTIES
     FIXTURES_REQUIRED "java-setup-c;java-setup-java")
+endif()
+
+
+#
+# Python tests
+if(CBF_ENABLE_PYTHON)
+  add_test(NAME pycbf-test1
+    COMMAND Python::Interpreter
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_test1.py"
+      "${CBF__DATA}/img2cif_packed.cif"
+      "${CBF__DATA}/pycbf_test1.raw")
+  set_tests_properties(pycbf-test1 PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pycbf"
+    FIXTURES_REQUIRED "img2cif-flatpacked-cif"
+    FIXTURES_SETUP pycbf-test1
+    REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_test1.py")
+
+  add_test(NAME pycbf-test1-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/pycbf_test1.raw")
+  set_tests_properties(pycbf-test1-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-test1)
+
+  add_test(NAME pycbf-test1-standardize-numbers
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:cbf_standardize_numbers>;-;4"
+      "-Dinput-file=${CBF__DATA}/pycbf_test1.raw"
+      "-Doutput-file=${CBF__DATA}/pycbf_test1.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake")
+  set_tests_properties(pycbf-test1-standardize-numbers PROPERTIES
+    FIXTURES_REQUIRED pycbf-test1
+    FIXTURES_SETUP pycbf-test1-standardize-numbers)
+
+  add_test(NAME pycbf-test1-standardize-numbers-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/pycbf_test1.out")
+  set_tests_properties(pycbf-test1-standardize-numbers-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-test1-standardize-numbers)
+
+  add_test(NAME pycbf-test1-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/pycbf_test1_orig.out"
+      "${CBF__DATA}/pycbf_test1.out")
+  set_tests_properties(pycbf-test1-cmp PROPERTIES
+    FIXTURES_REQUIRED pycbf-test1-standardize-numbers
+    REQUIRED_FILES "${data_output}/pycbf_test1_orig.out")
+
+
+  add_test(NAME pycbf-test2
+    COMMAND Python::Interpreter
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_test2.py"
+      "${CBF__DATA}/adscconverted.cbf"
+      "${CBF__DATA}/pycbf_test2.raw")
+  set_tests_properties(pycbf-test2 PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pycbf"
+    FIXTURES_REQUIRED "convert_image-adscimg"
+    FIXTURES_SETUP pycbf-test2
+    REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_test2.py")
+
+  add_test(NAME pycbf-test2-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/pycbf_test2.raw")
+  set_tests_properties(pycbf-test2-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-test2)
+
+  add_test(NAME pycbf-test2-standardize-numbers
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:cbf_standardize_numbers>;-;4"
+      "-Dinput-file=${CBF__DATA}/pycbf_test2.raw"
+      "-Doutput-file=${CBF__DATA}/pycbf_test2.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake")
+  set_tests_properties(pycbf-test2-standardize-numbers PROPERTIES
+    FIXTURES_REQUIRED pycbf-test2
+    FIXTURES_SETUP pycbf-test2-standardize-numbers)
+
+  add_test(NAME pycbf-test2-standardize-numbers-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/pycbf_test2.out")
+  set_tests_properties(pycbf-test2-standardize-numbers-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-test2-standardize-numbers)
+
+  add_test(NAME pycbf-test2-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/pycbf_test2_orig.out"
+      "${CBF__DATA}/pycbf_test2.out")
+  set_tests_properties(pycbf-test2-cmp PROPERTIES
+    FIXTURES_REQUIRED pycbf-test2-standardize-numbers
+    REQUIRED_FILES "${data_output}/pycbf_test2_orig.out")
+
+
+  add_test(NAME pycbf-test3
+    COMMAND Python::Interpreter
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_test3.py")
+  set_tests_properties(pycbf-test3 PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pycbf"
+    REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_test3.py")
+
+
+  add_test(NAME pycbf-test4
+    COMMAND Python::Interpreter
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_test4.py"
+      "${CBF__DATA}/img2cif_packed.cif"
+      "${CBF__DATA}/pycbf_test4.raw"
+      "${CBF__DATA}/newtest1.cbf")
+  set_tests_properties(pycbf-test4 PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pycbf"
+    FIXTURES_REQUIRED "img2cif-flatpacked-cif"
+    FIXTURES_SETUP pycbf-test4
+    REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_test4.py")
+
+  add_test(NAME pycbf-test4-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm
+      "${CBF__DATA}/pycbf_test4.raw"
+      "${CBF__DATA}/newtest1.cbf")
+  set_tests_properties(pycbf-test4-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-test4)
+
+  add_test(NAME pycbf-test4-standardize-numbers
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:cbf_standardize_numbers>;-;4"
+      "-Dinput-file=${CBF__DATA}/pycbf_test4.raw"
+      "-Doutput-file=${CBF__DATA}/pycbf_test4.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake")
+  set_tests_properties(pycbf-test4-standardize-numbers PROPERTIES
+    FIXTURES_REQUIRED pycbf-test4
+    FIXTURES_SETUP pycbf-test4-standardize-numbers)
+
+  add_test(NAME pycbf-test4-standardize-numbers-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/pycbf_test4.out")
+  set_tests_properties(pycbf-test4-standardize-numbers-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-test4-standardize-numbers)
+
+  add_test(NAME pycbf-test4-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/pycbf_test4_orig.out"
+      "${CBF__DATA}/pycbf_test4.out")
+  set_tests_properties(pycbf-test4-cmp PROPERTIES
+    FIXTURES_REQUIRED pycbf-test4-standardize-numbers
+    REQUIRED_FILES "${data_output}/pycbf_test4_orig.out")
+
+
+  add_test(NAME pycbf-fel1
+    COMMAND Python::Interpreter
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_testfelaxes.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/fel_test1.cbf"
+      "${CBF__DATA}/fel_test1.raw")
+  set_tests_properties(pycbf-fel1 PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pycbf"
+    FIXTURES_SETUP pycbf-fel1
+    REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/fel_test1.cbf")
+
+  add_test(NAME pycbf-fel1-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/fel_test1.raw")
+  set_tests_properties(pycbf-fel1-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-fel1)
+
+  add_test(NAME pycbf-fel1-standardize-numbers
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:cbf_standardize_numbers>;-;4"
+      "-Dinput-file=${CBF__DATA}/fel_test1.raw"
+      "-Doutput-file=${CBF__DATA}/fel_test1.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake")
+  set_tests_properties(pycbf-fel1-standardize-numbers PROPERTIES
+    FIXTURES_REQUIRED pycbf-fel1
+    FIXTURES_SETUP pycbf-fel1-standardize-numbers)
+
+  add_test(NAME pycbf-fel1-standardize-numbers-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/fel_test1.out")
+  set_tests_properties(pycbf-fel1-standardize-numbers-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-fel1-standardize-numbers)
+
+  add_test(NAME pycbf-fel1-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/fel_test1_orig.out"
+      "${CBF__DATA}/fel_test1.out")
+  set_tests_properties(pycbf-fel1-cmp PROPERTIES
+    FIXTURES_REQUIRED pycbf-fel1-standardize-numbers
+    REQUIRED_FILES "${data_output}/fel_test1_orig.out")
+
+
+  add_test(NAME pycbf-fel2
+    COMMAND Python::Interpreter
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_testfelaxes.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/fel_test2.cbf"
+      "${CBF__DATA}/fel_test2.raw")
+  set_tests_properties(pycbf-fel2 PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pycbf"
+    FIXTURES_SETUP pycbf-fel2
+    REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/fel_test2.cbf")
+
+  add_test(NAME pycbf-fel2-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/fel_test2.raw")
+  set_tests_properties(pycbf-fel2-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-fel2)
+
+  add_test(NAME pycbf-fel2-standardize-numbers
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:cbf_standardize_numbers>;-;4"
+      "-Dinput-file=${CBF__DATA}/fel_test2.raw"
+      "-Doutput-file=${CBF__DATA}/fel_test2.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake")
+  set_tests_properties(pycbf-fel2-standardize-numbers PROPERTIES
+    FIXTURES_REQUIRED pycbf-fel2
+    FIXTURES_SETUP pycbf-fel2-standardize-numbers)
+
+  add_test(NAME pycbf-fel2-standardize-numbers-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/fel_test2.out")
+  set_tests_properties(pycbf-fel2-standardize-numbers-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-fel2-standardize-numbers)
+
+  add_test(NAME pycbf-fel2-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/fel_test2_orig.out"
+      "${CBF__DATA}/fel_test2.out")
+  set_tests_properties(pycbf-fel2-cmp PROPERTIES
+    FIXTURES_REQUIRED pycbf-fel2-standardize-numbers
+    REQUIRED_FILES "${data_output}/fel_test2_orig.out")
+
+
+  add_test(NAME pycbf-fel3
+    COMMAND Python::Interpreter
+      "${CMAKE_CURRENT_SOURCE_DIR}/pycbf/pycbf_testfelaxes.py"
+      "${data_input}/hit-20140306005258847.cbf"
+      "${CBF__DATA}/fel_test3.raw")
+  set_tests_properties(pycbf-fel3 PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pycbf"
+    FIXTURES_SETUP pycbf-fel3
+    REQUIRED_FILES "${data_input}/hit-20140306005258847.cbf")
+
+  add_test(NAME pycbf-fel3-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/fel_test3.raw")
+  set_tests_properties(pycbf-fel3-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-fel3)
+
+  add_test(NAME pycbf-fel3-standardize-numbers
+    COMMAND ${CMAKE_COMMAND}
+      "-Dcommand=$<TARGET_FILE:cbf_standardize_numbers>;-;4"
+      "-Dinput-file=${CBF__DATA}/fel_test3.raw"
+      "-Doutput-file=${CBF__DATA}/fel_test3.out"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/redirect.cmake")
+  set_tests_properties(pycbf-fel3-standardize-numbers PROPERTIES
+    FIXTURES_REQUIRED pycbf-fel3
+    FIXTURES_SETUP pycbf-fel3-standardize-numbers)
+
+  add_test(NAME pycbf-fel3-standardize-numbers-cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm "${CBF__DATA}/fel_test3.out")
+  set_tests_properties(pycbf-fel3-standardize-numbers-cleanup PROPERTIES
+    FIXTURES_CLEANUP pycbf-fel3-standardize-numbers)
+
+  add_test(NAME pycbf-fel3-cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files
+      "${data_output}/fel_test3_orig.out"
+      "${CBF__DATA}/fel_test3.out")
+  set_tests_properties(pycbf-fel3-cmp PROPERTIES
+    FIXTURES_REQUIRED pycbf-fel3-standardize-numbers
+    REQUIRED_FILES "${data_output}/fel_test3_orig.out")
 endif()

--- a/Makefile
+++ b/Makefile
@@ -2968,8 +2968,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
-	  grep -v "__builtins__"  pycbf_test1.out | \
-	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
+	  $(DIFF) pycbf_test1.out pycbf_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
@@ -2977,8 +2976,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
-	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
-	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
+	  $(DIFF) pycbf_test4.out pycbf_test4_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)

--- a/Makefile
+++ b/Makefile
@@ -2965,25 +2965,25 @@ endif
 
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TESTOUTPUT)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
 	  grep -v "__builtins__"  pycbf_test1.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test3.out $(ROOT)/pycbf_test3_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
 	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
 	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test2.out $(ROOT)/fel_test2_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf fel_test3.raw; cat fel_test3.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test3.out $(ROOT)/fel_test3_orig.out)
 
 py3cbfinstall: $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(PY3CBF)/py3cbfinstall

--- a/Makefile_LINUX
+++ b/Makefile_LINUX
@@ -2964,8 +2964,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
-	  grep -v "__builtins__"  pycbf_test1.out | \
-	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
+	  $(DIFF) pycbf_test1.out pycbf_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
@@ -2973,8 +2972,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
-	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
-	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
+	  $(DIFF) pycbf_test4.out pycbf_test4_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)

--- a/Makefile_LINUX
+++ b/Makefile_LINUX
@@ -2961,25 +2961,25 @@ endif
 
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TESTOUTPUT)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
 	  grep -v "__builtins__"  pycbf_test1.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test3.out $(ROOT)/pycbf_test3_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
 	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
 	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test2.out $(ROOT)/fel_test2_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf fel_test3.raw; cat fel_test3.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test3.out $(ROOT)/fel_test3_orig.out)
 
 py3cbfinstall: $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(PY3CBF)/py3cbfinstall

--- a/Makefile_MINGW
+++ b/Makefile_MINGW
@@ -2978,8 +2978,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
-	  grep -v "__builtins__"  pycbf_test1.out | \
-	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
+	  $(DIFF) pycbf_test1.out pycbf_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
@@ -2987,8 +2986,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
-	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
-	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
+	  $(DIFF) pycbf_test4.out pycbf_test4_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)

--- a/Makefile_MINGW
+++ b/Makefile_MINGW
@@ -2975,25 +2975,25 @@ endif
 
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TESTOUTPUT)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
 	  grep -v "__builtins__"  pycbf_test1.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test3.out $(ROOT)/pycbf_test3_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
 	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
 	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test2.out $(ROOT)/fel_test2_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf fel_test3.raw; cat fel_test3.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test3.out $(ROOT)/fel_test3_orig.out)
 
 py3cbfinstall: $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(PY3CBF)/py3cbfinstall

--- a/Makefile_MSYS2
+++ b/Makefile_MSYS2
@@ -2960,25 +2960,25 @@ endif
 
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TESTOUTPUT)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
 	  grep -v "__builtins__"  pycbf_test1.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test3.out $(ROOT)/pycbf_test3_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
 	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
 	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test2.out $(ROOT)/fel_test2_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf fel_test3.raw; cat fel_test3.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test3.out $(ROOT)/fel_test3_orig.out)
 
 py3cbfinstall: $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(PY3CBF)/py3cbfinstall

--- a/Makefile_MSYS2
+++ b/Makefile_MSYS2
@@ -2963,8 +2963,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
-	  grep -v "__builtins__"  pycbf_test1.out | \
-	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
+	  $(DIFF) pycbf_test1.out pycbf_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
@@ -2972,8 +2971,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
-	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
-	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
+	  $(DIFF) pycbf_test4.out pycbf_test4_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)

--- a/Makefile_OSX
+++ b/Makefile_OSX
@@ -2962,8 +2962,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
-	  grep -v "__builtins__"  pycbf_test1.out | \
-	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
+	  $(DIFF) pycbf_test1.out pycbf_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
@@ -2971,8 +2970,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
-	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
-	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
+	  $(DIFF) pycbf_test4.out pycbf_test4_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)

--- a/Makefile_OSX
+++ b/Makefile_OSX
@@ -2959,25 +2959,25 @@ endif
 
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TESTOUTPUT)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
 	  grep -v "__builtins__"  pycbf_test1.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test3.out $(ROOT)/pycbf_test3_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
 	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
 	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test2.out $(ROOT)/fel_test2_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf fel_test3.raw; cat fel_test3.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test3.out $(ROOT)/fel_test3_orig.out)
 
 py3cbfinstall: $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(PY3CBF)/py3cbfinstall

--- a/m4/Makefile.m4
+++ b/m4/Makefile.m4
@@ -3337,8 +3337,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
-	  grep -v "__builtins__"  pycbf_test1.out | \
-	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
+	  $(DIFF) pycbf_test1.out pycbf_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
@@ -3346,8 +3345,7 @@ py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TES
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
-	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
-	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
+	  $(DIFF) pycbf_test4.out pycbf_test4_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)

--- a/m4/Makefile.m4
+++ b/m4/Makefile.m4
@@ -3334,25 +3334,25 @@ endif
 
 ifneq ($(CBFLIB_DONT_USE_PY3CIFRW),yes)
 py3cbftests:  $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(BIN)/cbf_standardize_numbers $(TESTOUTPUT)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test1.py ../img2cif_packed.cif pycbf_test1.raw; cat pycbf_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test1.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test1_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test1_orig.out; \
 	  grep -v "__builtins__"  pycbf_test1.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" |$(DIFF) - pycbf_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test2.py ../adscconverted.cbf pycbf_test2.raw; cat pycbf_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test2.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test2.out $(ROOT)/pycbf_test2_orig.out)
 	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test3.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test3.out)
 	-(cd $(PY3CBF); $(DIFF) pycbf_test3.out $(ROOT)/pycbf_test3_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_test4.py ../img2cif_packed.cif pycbf_test4.raw newtest1.cbf; cat pycbf_test4.raw | $(BIN)/cbf_standardize_numbers - 4 > pycbf_test4.out)
 	-(cd $(PY3CBF); grep -v "__builtins__" $(ROOT)/pycbf_test4_orig.out | \
 	  grep -v "__add__" | grep -v "Foundthebinary" > pycbf_test4_orig.out; \
 	  grep -v "__builtins__"  pycbf_test4.out | grep -v "__add__" | \
 	  grep -v "Foundthebinary" | $(DIFF) - pycbf_test4_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test1.cbf fel_test1.raw; cat fel_test1.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test1.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test1.out $(ROOT)/fel_test1_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py fel_test2.cbf fel_test2.raw; cat fel_test2.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test2.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test2.out $(ROOT)/fel_test2_orig.out)
-	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
+	($(RTLPEXPORTS) cd $(PY3CBF); $(PYTHON3) $(PY3CBF)/pycbf_testfelaxes.py ../hit-20140306005258847.cbf fel_test3.raw; cat fel_test3.raw | $(BIN)/cbf_standardize_numbers - 4 > fel_test3.out)
 	-(cd $(PY3CBF); $(DIFF) fel_test3.out $(ROOT)/fel_test3_orig.out)
 
 py3cbfinstall: $(PY3CBF)/_pycbf.$(PY3CBFEXT) $(PY3CBF)/py3cbfinstall

--- a/patches/cbflib-data-output-0.9.8.patch
+++ b/patches/cbflib-data-output-0.9.8.patch
@@ -62,3 +62,34 @@
  
  data_image_1
  
+--- a/pycbf_test1_orig.out
++++ b/pycbf_test1_orig.out
+@@ -142,12 +142,9 @@
+ col:array_idtype:word
+ Val:1 11 
+ col:binary_idtype:bnry
+-Foundthebinary!!<type'str'>
+-[ '__add__',  '__class__',  '__contains__',  '__delattr__',  '__doc__',  '__eq__',  '__format__',  '__ge__',  '__getattribute__',  '__getitem__',  '__getnewargs__',  '__getslice__',  '__gt__',  '__hash__',  '__init__',  '__le__',  '__len__',  '__lt__',  '__mod__',  '__mul__',  '__ne__',  '__new__',  '__reduce__',  '__reduce_ex__',  '__repr__',  '__rmod__',  '__rmul__',  '__setattr__',  '__sizeof__',  '__str__',  '__subclasshook__',  '_formatter_field_name_split',  '_formatter_parser',  'capitalize',  'center',  'count',  'decode',  'encode',  'endswith',  'expandtabs',  'find',  'format',  'index',  'isalnum',  'isalpha',  'isdigit',  'islower',  'isspace',  'istitle',  'isupper',  'join',  'ljust',  'lower',  'lstrip',  'partition',  'replace',  'rfind',  'rindex',  'rjust',  'rpartition',  'rsplit',  'rstrip',  'split',  'splitlines',  'startswith',  'strip',  'swapcase',  'title',  'translate',  'upper',  'zfill']  
+ 2.116e+07 
+ ( 5.29e+06 ,  )  
+ [ 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ]  56 0 
+ [ 409 , 410 , 388 , 402 , 407 , 408 , 412 , 403 , 427 , 416 , 420 , 396 , 393 , 426 , 463 , 457 , 440 , 422 
+ 459 430 ]
+ 
+-[ '__builtins__',  '__doc__',  '__file__',  '__name__',  '__package__',  'categories',  'category_name',  'cols',  'column_name',  'd',  'i',  'j',  'k',  'loop',  'name',  'numpy',  'pycbf',  'rows',  's',  'typeofvalue',  'value']  
+--- a/pycbf_test4_orig.out
++++ b/pycbf_test4_orig.out
+@@ -142,8 +142,6 @@
+ col:array_idtype:word
+ Val:1 11 
+ col:binary_idtype:bnry
+-Foundthebinary!!<type'str'>
+-[ '__add__',  '__class__',  '__contains__',  '__delattr__',  '__doc__',  '__eq__',  '__format__',  '__ge__',  '__getattribute__',  '__getitem__',  '__getnewargs__',  '__getslice__',  '__gt__',  '__hash__',  '__init__',  '__le__',  '__len__',  '__lt__',  '__mod__',  '__mul__',  '__ne__',  '__new__',  '__reduce__',  '__reduce_ex__',  '__repr__',  '__rmod__',  '__rmul__',  '__setattr__',  '__sizeof__',  '__str__',  '__subclasshook__',  '_formatter_field_name_split',  '_formatter_parser',  'capitalize',  'center',  'count',  'decode',  'encode',  'endswith',  'expandtabs',  'find',  'format',  'index',  'isalnum',  'isalpha',  'isdigit',  'islower',  'isspace',  'istitle',  'isupper',  'join',  'ljust',  'lower',  'lstrip',  'partition',  'replace',  'rfind',  'rindex',  'rjust',  'rpartition',  'rsplit',  'rstrip',  'split',  'splitlines',  'startswith',  'strip',  'swapcase',  'title',  'translate',  'upper',  'zfill']  
+ 2.116e+07 
+ compression:608 
+ binaryid1 
+@@ -163,4 +161,3 @@
+ [ 409 , 410 , 388 , 402 , 407 , 408 , 412 , 403 , 427 , 416 , 420 , 396 , 393 , 426 , 463 , 457 , 440 , 422 
+ 459 430 ]
+ 
+-[ '__builtins__',  '__doc__',  '__file__',  '__name__',  '__package__',  'binaryid',  'byteorder',  'categories',  'category_name',  'cols',  'column_name',  'compression',  'd',  'dimfast',  'dimmid',  'dimslow',  'elements',  'elsigned',  'elsize',  'elunsigned',  'i',  'j',  'k',  'loop',  'maxelement',  'minelement',  'name',  'newobject',  'numpy',  'padding',  'pycbf',  'rows',  's',  'typeofvalue',  'value']  

--- a/pycbf/pycbf.tex
+++ b/pycbf/pycbf.tex
@@ -4579,73 +4579,74 @@ when you build CBFlib, hence that file is hardwired in.
 \NWtarget{nuweb14}{} \verb@"pycbf_test1.py"@\nobreak\ {\footnotesize {14}}$\equiv$
 \vspace{-1ex}
 \begin{list}{}{} \item
+\mbox{}\verb@from sys import argv@\\
 \mbox{}\verb@@\\
 \mbox{}\verb@import pycbf@\\
 \mbox{}\verb@object = pycbf.cbf_handle_struct() # FIXME@\\
-\mbox{}\verb@object.read_file(b"../img2cif_packed.cif",pycbf.MSG_DIGEST)@\\
+\mbox{}\verb@object.read_file(argv[1].encode(),pycbf.MSG_DIGEST)@\\
 \mbox{}\verb@object.rewind_datablock()@\\
-\mbox{}\verb@print("Found",object.count_datablocks(),"blocks")@\\
-\mbox{}\verb@object.select_datablock(0)@\\
-\mbox{}\verb@print("Zeroth is named",object.datablock_name())@\\
-\mbox{}\verb@object.rewind_category()@\\
-\mbox{}\verb@categories = object.count_categories()@\\
-\mbox{}\verb@for i in range(categories):@\\
-\mbox{}\verb@    print("Category:",i, end=' ')@\\
-\mbox{}\verb@    object.select_category(i)@\\
-\mbox{}\verb@    category_name = object.category_name()@\\
-\mbox{}\verb@    print("Name:",category_name, end=' ')@\\
-\mbox{}\verb@    rows=object.count_rows()@\\
-\mbox{}\verb@    print("Rows:",rows, end=' ')@\\
-\mbox{}\verb@    cols = object.count_columns()@\\
-\mbox{}\verb@    print("Cols:",cols)@\\
-\mbox{}\verb@    loop=1@\\
-\mbox{}\verb@    object.rewind_column()@\\
-\mbox{}\verb@    while loop==1:@\\
-\mbox{}\verb@        column_name = object.column_name()@\\
-\mbox{}\verb@        print("column name \"",column_name,"\"", end=' ')@\\
-\mbox{}\verb@        try:@\\
-\mbox{}\verb@           object.next_column()@\\
-\mbox{}\verb@        except:@\\
-\mbox{}\verb@           break@\\
-\mbox{}\verb@    print@\\
-\mbox{}\verb@    for j in range(rows):@\\
-\mbox{}\verb@        object.select_row(j)@\\
+\mbox{}\verb@with open(argv[2],'w',newline='\n') as f:@\\
+\mbox{}\verb@    print("Found",object.count_datablocks(),"blocks",file=f)@\\
+\mbox{}\verb@    object.select_datablock(0)@\\
+\mbox{}\verb@    print("Zeroth is named",object.datablock_name(),file=f)@\\
+\mbox{}\verb@    object.rewind_category()@\\
+\mbox{}\verb@    categories = object.count_categories()@\\
+\mbox{}\verb@    for i in range(categories):@\\
+\mbox{}\verb@        print("Category:",i, end=' ', file=f)@\\
+\mbox{}\verb@        object.select_category(i)@\\
+\mbox{}\verb@        category_name = object.category_name()@\\
+\mbox{}\verb@        print("Name:",category_name, end=' ', file=f)@\\
+\mbox{}\verb@        rows=object.count_rows()@\\
+\mbox{}\verb@        print("Rows:",rows, end=' ', file=f)@\\
+\mbox{}\verb@        cols = object.count_columns()@\\
+\mbox{}\verb@        print("Cols:",cols,file=f)@\\
+\mbox{}\verb@        loop=1@\\
 \mbox{}\verb@        object.rewind_column()@\\
-\mbox{}\verb@        if j==0: print()@\\
-\mbox{}\verb@        print("row:",j)@\\
-\mbox{}\verb@        for k in range(cols):@\\
-\mbox{}\verb@            name=object.column_name()@\\
-\mbox{}\verb@            print("col:",name, end=' ')@\\
-\mbox{}\verb@            object.select_column(k)@\\
-\mbox{}\verb@            typeofvalue=object.get_typeofvalue()@\\
-\mbox{}\verb@            print("type:",typeofvalue)@\\
-\mbox{}\verb@            if typeofvalue.find(b"bnry") > -1:@\\
-\mbox{}\verb@                print("Found the binary!!", end=' ')@\\
-\mbox{}\verb@                s=object.get_integerarray_as_string()@\\
-\mbox{}\verb@                print(type(str(s)))@\\
-\mbox{}\verb@                print(dir(str(s)))@\\
-\mbox{}\verb@                print(len(s))@\\
-\mbox{}\verb@                try:@\\
-\mbox{}\verb@                   import numpy @\\
-\mbox{}\verb@                   d = numpy.frombuffer(bytes(s),numpy.uint32)@\\
-\mbox{}\verb@                   # Hard wired Unsigned Int32@\\
-\mbox{}\verb@                   print(d.shape)@\\
-\mbox{}\verb@                   print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1])@\\
-\mbox{}\verb@                   print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)])@\\
-\mbox{}\verb@                   d=numpy.reshape(d,(2300,2300))@\\
-\mbox{}\verb@#                   from matplotlib import pylab@\\
-\mbox{}\verb@#                   pylab.imshow(d,vmin=0,vmax=1000)@\\
-\mbox{}\verb@#                   pylab.show()@\\
-\mbox{}\verb@                except ImportError:@\\
-\mbox{}\verb@                   print("You need to get numpy and matplotlib to see the data")@\\
-\mbox{}\verb@            else:@\\
-\mbox{}\verb@                value=object.get_value()@\\
-\mbox{}\verb@                print("Val:",value,i)@\\
-\mbox{}\verb@    print()@\\
-\mbox{}\verb@del(object)@\\
-\mbox{}\verb@#@\\
-\mbox{}\verb@print(dir())@\\
-\mbox{}\verb@#object.free_handle(handle)@\\
+\mbox{}\verb@        while loop==1:@\\
+\mbox{}\verb@            column_name = object.column_name()@\\
+\mbox{}\verb@            print("column name \"",column_name,"\"", end=' ', file=f)@\\
+\mbox{}\verb@            try:@\\
+\mbox{}\verb@               object.next_column()@\\
+\mbox{}\verb@            except:@\\
+\mbox{}\verb@               break@\\
+\mbox{}\verb@        for j in range(rows):@\\
+\mbox{}\verb@            object.select_row(j)@\\
+\mbox{}\verb@            object.rewind_column()@\\
+\mbox{}\verb@            if j==0: print(file=f)@\\
+\mbox{}\verb@            print("row:",j,file=f)@\\
+\mbox{}\verb@            for k in range(cols):@\\
+\mbox{}\verb@                name=object.column_name()@\\
+\mbox{}\verb@                print("col:",name, end=' ', file=f)@\\
+\mbox{}\verb@                object.select_column(k)@\\
+\mbox{}\verb@                typeofvalue=object.get_typeofvalue()@\\
+\mbox{}\verb@                print("type:",typeofvalue,file=f)@\\
+\mbox{}\verb@                if typeofvalue.find(b"bnry") > -1:@\\
+\mbox{}\verb@                    print("Found the binary!!", end=' ', file=f)@\\
+\mbox{}\verb@                    s=object.get_integerarray_as_string()@\\
+\mbox{}\verb@                    print(type(str(s)), file=f)@\\
+\mbox{}\verb@                    print(dir(str(s)), file=f)@\\
+\mbox{}\verb@                    print(len(s), file=f)@\\
+\mbox{}\verb@                    try:@\\
+\mbox{}\verb@                       import numpy@\\
+\mbox{}\verb@                       d = numpy.frombuffer(bytes(s),numpy.uint32)@\\
+\mbox{}\verb@                       # Hard wired Unsigned Int32@\\
+\mbox{}\verb@                       print(d.shape, file=f)@\\
+\mbox{}\verb@                       print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1],file=f)@\\
+\mbox{}\verb@                       print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)], file=f)@\\
+\mbox{}\verb@                       d=numpy.reshape(d,(2300,2300))@\\
+\mbox{}\verb@    #                   from matplotlib import pylab@\\
+\mbox{}\verb@    #                   pylab.imshow(d,vmin=0,vmax=1000)@\\
+\mbox{}\verb@    #                   pylab.show()@\\
+\mbox{}\verb@                    except ImportError:@\\
+\mbox{}\verb@                       print("You need to get numpy and matplotlib to see the data", file=f)@\\
+\mbox{}\verb@                else:@\\
+\mbox{}\verb@                    value=object.get_value()@\\
+\mbox{}\verb@                    print("Val:",value,i,file=f)@\\
+\mbox{}\verb@        print(file=f)@\\
+\mbox{}\verb@    del(object)@\\
+\mbox{}\verb@    #@\\
+\mbox{}\verb@    print(dir(), file=f)@\\
+\mbox{}\verb@    #object.free_handle(handle)@\\
 \mbox{}\verb@@{\NWsep}
 \end{list}
 \vspace{-1.5ex}
@@ -4671,18 +4672,20 @@ a single member function.
 \NWtarget{nuweb15a}{} \verb@"pycbf_test2.py"@\nobreak\ {\footnotesize {15a}}$\equiv$
 \vspace{-1ex}
 \begin{list}{}{} \item
+\mbox{}\verb@from sys import argv@\\
 \mbox{}\verb@@\\
 \mbox{}\verb@import pycbf@\\
 \mbox{}\verb@obj = pycbf.cbf_handle_struct()@\\
-\mbox{}\verb@obj.read_file(b"../adscconverted.cbf",0)@\\
+\mbox{}\verb@obj.read_file(argv[1].encode(),0)@\\
 \mbox{}\verb@obj.select_datablock(0)@\\
 \mbox{}\verb@g = obj.construct_goniometer()@\\
-\mbox{}\verb@print("Rotation axis is",g.get_rotation_axis())@\\
-\mbox{}\verb@d = obj.construct_detector(0)@\\
-\mbox{}\verb@print("Beam center is",d.get_beam_center())@\\
-\mbox{}\verb@print("Detector slow axis is", d.get_detector_axis_slow())@\\
-\mbox{}\verb@print("Detector fast axis is", d.get_detector_axis_fast())@\\
-\mbox{}\verb@print("Detector axes (fast, slow) are", d.get_detector_axes_fs())@\\
+\mbox{}\verb@with open(argv[2],'w',newline='\n') as f:@\\
+\mbox{}\verb@    print("Rotation axis is",g.get_rotation_axis(),file=f)@\\
+\mbox{}\verb@    d = obj.construct_detector(0)@\\
+\mbox{}\verb@    print("Beam center is",d.get_beam_center(),file=f)@\\
+\mbox{}\verb@    print("Detector slow axis is", d.get_detector_axis_slow(), file=f)@\\
+\mbox{}\verb@    print("Detector fast axis is", d.get_detector_axis_fast(), file=f)@\\
+\mbox{}\verb@    print("Detector axes (fast, slow) are", d.get_detector_axes_fs(), file=f)@\\
 \mbox{}\verb@@{\NWsep}
 \end{list}
 \vspace{-1.5ex}
@@ -4702,7 +4705,6 @@ It appears to work - eventually. Surprising
 \NWtarget{nuweb15b}{} \verb@"pycbf_test3.py"@\nobreak\ {\footnotesize {15b}}$\equiv$
 \vspace{-1ex}
 \begin{list}{}{} \item
-\mbox{}\verb@@\\
 \mbox{}\verb@import pycbf, unittest@\\
 \mbox{}\verb@class GenericTests(unittest.TestCase):@\\
 \mbox{}\verb@@\\
@@ -4727,7 +4729,6 @@ It appears to work - eventually. Surprising
 \mbox{}\verb@                           24.0)@\\
 \mbox{}\verb@if __name__=="__main__":@\\
 \mbox{}\verb@    unittest.main()@\\
-\mbox{}\verb@@\\
 \mbox{}\verb@@{\NWsep}
 \end{list}
 \vspace{-1.5ex}
@@ -4745,108 +4746,110 @@ It appears to work - eventually. Surprising
 \NWtarget{nuweb17}{} \verb@"pycbf_test4.py"@\nobreak\ {\footnotesize {17}}$\equiv$
 \vspace{-1ex}
 \begin{list}{}{} \item
+\mbox{}\verb@from sys import argv@\\
 \mbox{}\verb@@\\
 \mbox{}\verb@# version of pycbf_test1 with write logic added@\\
 \mbox{}\verb@import pycbf@\\
 \mbox{}\verb@object = pycbf.cbf_handle_struct()@\\
 \mbox{}\verb@newobject = pycbf.cbf_handle_struct()@\\
-\mbox{}\verb@object.read_file(b"../img2cif_packed.cif",pycbf.MSG_DIGEST)@\\
+\mbox{}\verb@object.read_file(argv[1].encode(),pycbf.MSG_DIGEST)@\\
 \mbox{}\verb@object.rewind_datablock()@\\
-\mbox{}\verb@print("Found",object.count_datablocks(),"blocks")@\\
-\mbox{}\verb@object.select_datablock(0)@\\
-\mbox{}\verb@print("Zeroth is named",object.datablock_name())@\\
-\mbox{}\verb@newobject.force_new_datablock(object.datablock_name());@\\
-\mbox{}\verb@object.rewind_category()@\\
-\mbox{}\verb@categories = object.count_categories()@\\
-\mbox{}\verb@for i in range(categories):@\\
-\mbox{}\verb@    print("Category:",i, end= ' ')@\\
-\mbox{}\verb@    object.select_category(i)@\\
-\mbox{}\verb@    category_name = object.category_name()@\\
-\mbox{}\verb@    print("Name:",category_name, end=' ')@\\
-\mbox{}\verb@    newobject.new_category(category_name)@\\
-\mbox{}\verb@    rows=object.count_rows()@\\
-\mbox{}\verb@    print("Rows:",rows, end=' ')@\\
-\mbox{}\verb@    cols = object.count_columns()@\\
-\mbox{}\verb@    print("Cols:",cols)@\\
-\mbox{}\verb@    loop=1@\\
-\mbox{}\verb@    object.rewind_column()@\\
-\mbox{}\verb@    while loop==1:@\\
-\mbox{}\verb@        column_name = object.column_name()@\\
-\mbox{}\verb@        print("column name \"",column_name,"\"", end=' ')@\\
-\mbox{}\verb@        newobject.new_column(column_name)@\\
-\mbox{}\verb@        try:@\\
-\mbox{}\verb@           object.next_column()@\\
-\mbox{}\verb@        except:@\\
-\mbox{}\verb@            break@\\
-\mbox{}\verb@    print()@\\
-\mbox{}\verb@    for j in range(rows):@\\
-\mbox{}\verb@        object.select_row(j)@\\
-\mbox{}\verb@        newobject.new_row()@\\
+\mbox{}\verb@with open(argv[2],'w',newline='\n') as f:@\\
+\mbox{}\verb@    print("Found",object.count_datablocks(),"blocks",file=f)@\\
+\mbox{}\verb@    object.select_datablock(0)@\\
+\mbox{}\verb@    print("Zeroth is named",object.datablock_name(),file=f)@\\
+\mbox{}\verb@    newobject.force_new_datablock(object.datablock_name());@\\
+\mbox{}\verb@    object.rewind_category()@\\
+\mbox{}\verb@    categories = object.count_categories()@\\
+\mbox{}\verb@    for i in range(categories):@\\
+\mbox{}\verb@        print("Category:",i, end= ' ', file=f)@\\
+\mbox{}\verb@        object.select_category(i)@\\
+\mbox{}\verb@        category_name = object.category_name()@\\
+\mbox{}\verb@        print("Name:",category_name, end=' ', file=f)@\\
+\mbox{}\verb@        newobject.new_category(category_name)@\\
+\mbox{}\verb@        rows=object.count_rows()@\\
+\mbox{}\verb@        print("Rows:",rows, end=' ', file=f)@\\
+\mbox{}\verb@        cols = object.count_columns()@\\
+\mbox{}\verb@        print("Cols:",cols,file=f)@\\
+\mbox{}\verb@        loop=1@\\
 \mbox{}\verb@        object.rewind_column()@\\
-\mbox{}\verb@        print("row:",j)@\\
-\mbox{}\verb@        for k in range(cols):@\\
-\mbox{}\verb@            name=object.column_name()@\\
-\mbox{}\verb@            print("col:",name, end=' ')@\\
-\mbox{}\verb@            object.select_column(k)@\\
-\mbox{}\verb@            newobject.select_column(k)@\\
-\mbox{}\verb@            typeofvalue=object.get_typeofvalue()@\\
-\mbox{}\verb@            print("type:",typeofvalue)@\\
-\mbox{}\verb@            if typeofvalue.find(b"bnry") > -1:@\\
-\mbox{}\verb@                print("Found the binary!!",end=' ')@\\
-\mbox{}\verb@                s=object.get_integerarray_as_string()@\\
-\mbox{}\verb@                print(type(s))@\\
-\mbox{}\verb@                print(dir(s))@\\
-\mbox{}\verb@                print(len(s))@\\
-\mbox{}\verb@                (compression, binaryid, elsize, elsigned, \@\\
-\mbox{}\verb@                    elunsigned, elements, minelement, maxelement, \@\\
-\mbox{}\verb@                    byteorder,dimfast,dimmid,dimslow,padding) = \@\\
-\mbox{}\verb@                    object.get_integerarrayparameters_wdims_fs()@\\
-\mbox{}\verb@                if dimfast==0:@\\
-\mbox{}\verb@                    dimfast = 1@\\
-\mbox{}\verb@                if dimmid==0:@\\
-\mbox{}\verb@                    dimmid = 1@\\
-\mbox{}\verb@                if dimslow == 0:@\\
-\mbox{}\verb@                    dimslow = 1@\\
-\mbox{}\verb@                print("compression: ",compression)@\\
-\mbox{}\verb@                print("binaryid", binaryid)@\\
-\mbox{}\verb@                print("elsize", elsize)@\\
-\mbox{}\verb@                print("elsigned", elsigned)@\\
-\mbox{}\verb@                print("elunsigned",elunsigned)@\\
-\mbox{}\verb@                print("elements", elements)@\\
-\mbox{}\verb@                print("minelement", minelement)@\\
-\mbox{}\verb@                print("maxelement", maxelement)@\\
-\mbox{}\verb@                print("byteorder", byteorder)@\\
-\mbox{}\verb@                print("dimfast", dimfast)@\\
-\mbox{}\verb@                print("dimmid", dimmid)@\\
-\mbox{}\verb@                print("dimslow",dimslow)@\\
-\mbox{}\verb@                print("padding", padding)@\\
-\mbox{}\verb@                newobject.set_integerarray_wdims_fs(\@\\
-\mbox{}\verb@                  pycbf.CBF_BYTE_OFFSET,binaryid,s,elsize,elsigned,\@\\
-\mbox{}\verb@                  elements,byteorder,dimfast,dimmid,dimslow,padding)@\\
-\mbox{}\verb@                try:@\\
-\mbox{}\verb@                   import numpy@\\
-\mbox{}\verb@                   d = numpy.frombuffer(s,numpy.uint32)@\\
-\mbox{}\verb@                   # Hard wired Unsigned Int32@\\
-\mbox{}\verb@                   print(d.shape)@\\
-\mbox{}\verb@                   print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1])@\\
-\mbox{}\verb@                   print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)])@\\
-\mbox{}\verb@                   d=numpy.reshape(d,(2300,2300))@\\
-\mbox{}\verb@#                   from matplotlib import pylab@\\
-\mbox{}\verb@#                   pylab.imshow(d,vmin=0,vmax=1000)@\\
-\mbox{}\verb@#                   pylab.show()@\\
-\mbox{}\verb@                except ImportError:@\\
-\mbox{}\verb@                   print("You need to get numpy and matplotlib to see the data")@\\
-\mbox{}\verb@            else:@\\
-\mbox{}\verb@                value=object.get_value()@\\
-\mbox{}\verb@                newobject.set_value(value)@\\
-\mbox{}\verb@                print("Val:",value,i)@\\
-\mbox{}\verb@    print()@\\
-\mbox{}\verb@del(object)@\\
-\mbox{}\verb@newobject.write_widefile(b"newtest1.cbf",pycbf.CBF,\@\\
-\mbox{}\verb@    pycbf.MIME_HEADERS|pycbf.MSG_DIGEST|pycbf.PAD_4K,0)@\\
-\mbox{}\verb@#@\\
-\mbox{}\verb@print(dir())@\\
-\mbox{}\verb@#object.free_handle(handle)@\\
+\mbox{}\verb@        while loop==1:@\\
+\mbox{}\verb@            column_name = object.column_name()@\\
+\mbox{}\verb@            print("column name \"",column_name,"\"", end=' ', file=f)@\\
+\mbox{}\verb@            newobject.new_column(column_name)@\\
+\mbox{}\verb@            try:@\\
+\mbox{}\verb@               object.next_column()@\\
+\mbox{}\verb@            except:@\\
+\mbox{}\verb@                break@\\
+\mbox{}\verb@        print(file=f)@\\
+\mbox{}\verb@        for j in range(rows):@\\
+\mbox{}\verb@            object.select_row(j)@\\
+\mbox{}\verb@            newobject.new_row()@\\
+\mbox{}\verb@            object.rewind_column()@\\
+\mbox{}\verb@            print("row:",j,file=f)@\\
+\mbox{}\verb@            for k in range(cols):@\\
+\mbox{}\verb@                name=object.column_name()@\\
+\mbox{}\verb@                print("col:",name, end=' ', file=f)@\\
+\mbox{}\verb@                object.select_column(k)@\\
+\mbox{}\verb@                newobject.select_column(k)@\\
+\mbox{}\verb@                typeofvalue=object.get_typeofvalue()@\\
+\mbox{}\verb@                print("type:",typeofvalue,file=f)@\\
+\mbox{}\verb@                if typeofvalue.find(b"bnry") > -1:@\\
+\mbox{}\verb@                    print("Found the binary!!",end=' ',file=f)@\\
+\mbox{}\verb@                    s=object.get_integerarray_as_string()@\\
+\mbox{}\verb@                    print(type(s), file=f)@\\
+\mbox{}\verb@                    print(dir(s), file=f)@\\
+\mbox{}\verb@                    print(len(s), file=f)@\\
+\mbox{}\verb@                    (compression, binaryid, elsize, elsigned, \@\\
+\mbox{}\verb@                        elunsigned, elements, minelement, maxelement, \@\\
+\mbox{}\verb@                        byteorder,dimfast,dimmid,dimslow,padding) = \@\\
+\mbox{}\verb@                        object.get_integerarrayparameters_wdims_fs()@\\
+\mbox{}\verb@                    if dimfast==0:@\\
+\mbox{}\verb@                        dimfast = 1@\\
+\mbox{}\verb@                    if dimmid==0:@\\
+\mbox{}\verb@                        dimmid = 1@\\
+\mbox{}\verb@                    if dimslow == 0:@\\
+\mbox{}\verb@                        dimslow = 1@\\
+\mbox{}\verb@                    print("compression: ",compression,file=f)@\\
+\mbox{}\verb@                    print("binaryid", binaryid, file=f)@\\
+\mbox{}\verb@                    print("elsize", elsize, file=f)@\\
+\mbox{}\verb@                    print("elsigned", elsigned, file=f)@\\
+\mbox{}\verb@                    print("elunsigned",elunsigned,file=f)@\\
+\mbox{}\verb@                    print("elements", elements, file=f)@\\
+\mbox{}\verb@                    print("minelement", minelement, file=f)@\\
+\mbox{}\verb@                    print("maxelement", maxelement, file=f)@\\
+\mbox{}\verb@                    print("byteorder", byteorder, file=f)@\\
+\mbox{}\verb@                    print("dimfast", dimfast, file=f)@\\
+\mbox{}\verb@                    print("dimmid", dimmid, file=f)@\\
+\mbox{}\verb@                    print("dimslow",dimslow,file=f)@\\
+\mbox{}\verb@                    print("padding", padding, file=f)@\\
+\mbox{}\verb@                    newobject.set_integerarray_wdims_fs(\@\\
+\mbox{}\verb@                      pycbf.CBF_BYTE_OFFSET,binaryid,s,elsize,elsigned,\@\\
+\mbox{}\verb@                      elements,byteorder,dimfast,dimmid,dimslow,padding)@\\
+\mbox{}\verb@                    try:@\\
+\mbox{}\verb@                       import numpy@\\
+\mbox{}\verb@                       d = numpy.frombuffer(s,numpy.uint32)@\\
+\mbox{}\verb@                       # Hard wired Unsigned Int32@\\
+\mbox{}\verb@                       print(d.shape, file=f)@\\
+\mbox{}\verb@                       print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1],file=f)@\\
+\mbox{}\verb@                       print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)], file=f)@\\
+\mbox{}\verb@                       d=numpy.reshape(d,(2300,2300))@\\
+\mbox{}\verb@    #                   from matplotlib import pylab@\\
+\mbox{}\verb@    #                   pylab.imshow(d,vmin=0,vmax=1000)@\\
+\mbox{}\verb@    #                   pylab.show()@\\
+\mbox{}\verb@                    except ImportError:@\\
+\mbox{}\verb@                       print("You need to get numpy and matplotlib to see the data", file=f)@\\
+\mbox{}\verb@                else:@\\
+\mbox{}\verb@                    value=object.get_value()@\\
+\mbox{}\verb@                    newobject.set_value(value)@\\
+\mbox{}\verb@                    print("Val:",value,i,file=f)@\\
+\mbox{}\verb@        print(file=f)@\\
+\mbox{}\verb@    del(object)@\\
+\mbox{}\verb@    newobject.write_widefile(argv[3].encode(),pycbf.CBF,\@\\
+\mbox{}\verb@        pycbf.MIME_HEADERS|pycbf.MSG_DIGEST|pycbf.PAD_4K,0)@\\
+\mbox{}\verb@    #@\\
+\mbox{}\verb@    print(dir(), file=f)@\\
+\mbox{}\verb@    #object.free_handle(handle)@\\
 \mbox{}\verb@@{\NWsep}
 \end{list}
 \vspace{-1.5ex}
@@ -4864,7 +4867,6 @@ It appears to work - eventually. Surprising
 \NWtarget{nuweb18}{} \verb@"pycbf_testfelaxes.py"@\nobreak\ {\footnotesize {18}}$\equiv$
 \vspace{-1ex}
 \begin{list}{}{} \item
-\mbox{}\verb@@\\
 \mbox{}\verb@import pycbf, sys@\\
 \mbox{}\verb@from decimal import Decimal, ROUND_HALF_UP@\\
 \mbox{}\verb@@\\
@@ -4873,41 +4875,42 @@ It appears to work - eventually. Surprising
 \mbox{}\verb@cbf = pycbf.cbf_handle_struct()@\\
 \mbox{}\verb@cbf.read_widefile(image_file, pycbf.MSG_DIGEST)@\\
 \mbox{}\verb@@\\
-\mbox{}\verb@for element in range(64):@\\
-\mbox{}\verb@    d = cbf.construct_detector(element)@\\
-\mbox{}\verb@    print("element:", element)@\\
+\mbox{}\verb@with open(sys.argv[2],'w',newline='\n') as f:@\\
+\mbox{}\verb@    for element in range(64):@\\
+\mbox{}\verb@        d = cbf.construct_detector(element)@\\
+\mbox{}\verb@        print("element:", element, file=f)@\\
 \mbox{}\verb@@\\
-\mbox{}\verb@    v00 = d.get_pixel_coordinates(0, 0)@\\
-\mbox{}\verb@    v01 = d.get_pixel_coordinates(0, 1)@\\
-\mbox{}\verb@    v10 = d.get_pixel_coordinates(1, 0)@\\
-\mbox{}\verb@    v11 = d.get_pixel_coordinates(1, 1)@\\
-\mbox{}\verb@    prec = Decimal('1.000000000')@\\
+\mbox{}\verb@        v00 = d.get_pixel_coordinates(0, 0)@\\
+\mbox{}\verb@        v01 = d.get_pixel_coordinates(0, 1)@\\
+\mbox{}\verb@        v10 = d.get_pixel_coordinates(1, 0)@\\
+\mbox{}\verb@        v11 = d.get_pixel_coordinates(1, 1)@\\
+\mbox{}\verb@        prec = Decimal('1.000000000')@\\
 \mbox{}\verb@@\\
-\mbox{}\verb@    print('(0, 0) v00 [ %.9f %.9f %.9f ]' %(round(v00[0],9), round(v00[1],9), round(v00[2],9)))@\\
-\mbox{}\verb@    print('(0, 1) v01 [ %.9g %.9g %.9g ]' %(round(v01[0],9), round(v01[1],9), round(v01[2],9)))@\\
-\mbox{}\verb@    print('(1, 0) v10 [ %.9g %.9g %.9g ]' %(round(v10[0],9), round(v10[1],9), round(v10[2],9)))@\\
-\mbox{}\verb@    print('(1, 1) v11 [ %.9g %.9g %.9g ]' %(round(v11[0],9), round(v11[1],9), round(v11[2],9)))@\\
+\mbox{}\verb@        print('(0, 0) v00 [ %.9f %.9f %.9f ]' %(round(v00[0],9), round(v00[1],9), round(v00[2],9)), file=f)@\\
+\mbox{}\verb@        print('(0, 1) v01 [ %.9g %.9g %.9g ]' %(round(v01[0],9), round(v01[1],9), round(v01[2],9)), file=f)@\\
+\mbox{}\verb@        print('(1, 0) v10 [ %.9g %.9g %.9g ]' %(round(v10[0],9), round(v10[1],9), round(v10[2],9)), file=f)@\\
+\mbox{}\verb@        print('(1, 1) v11 [ %.9g %.9g %.9g ]' %(round(v11[0],9), round(v11[1],9), round(v11[2],9)), file=f)@\\
 \mbox{}\verb@@\\
-\mbox{}\verb@    print("surface axes:",  d.get_detector_surface_axes(0), d.get_detector_surface_axes(1))@\\
+\mbox{}\verb@        print("surface axes:",  d.get_detector_surface_axes(0), d.get_detector_surface_axes(1), file=f)@\\
 \mbox{}\verb@@\\
-\mbox{}\verb@    print(d.get_detector_surface_axes(0), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(0)), "ancestors")@\\
-\mbox{}\verb@    print(d.get_detector_surface_axes(1), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(1)), "ancestors")@\\
+\mbox{}\verb@        print(d.get_detector_surface_axes(0), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(0)), "ancestors", file=f)@\\
+\mbox{}\verb@        print(d.get_detector_surface_axes(1), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(1)), "ancestors", file=f)@\\
 \mbox{}\verb@@\\
-\mbox{}\verb@    cur_axis = d.get_detector_surface_axes(0)@\\
-\mbox{}\verb@    count = cbf.count_axis_ancestors(cur_axis)@\\
+\mbox{}\verb@        cur_axis = d.get_detector_surface_axes(0)@\\
+\mbox{}\verb@        count = cbf.count_axis_ancestors(cur_axis)@\\
 \mbox{}\verb@@\\
-\mbox{}\verb@    for index in range(count):@\\
-\mbox{}\verb@        print("axis", cur_axis, "index: ", index)@\\
-\mbox{}\verb@        print("    equipment", cbf.get_axis_equipment(cur_axis))@\\
-\mbox{}\verb@        print("    depends_on", cbf.get_axis_depends_on(cur_axis))@\\
-\mbox{}\verb@        print("    equipment_component", cbf.get_axis_equipment_component(cur_axis))@\\
-\mbox{}\verb@        vector = cbf.get_axis_vector(cur_axis)@\\
-\mbox{}\verb@        print("    vector [ %.8g %.8g %.8g ]" % (round(vector[0],7), round(vector[1],7), round(vector[2],7)))@\\
-\mbox{}\verb@        offset = cbf.get_axis_offset(cur_axis)@\\
-\mbox{}\verb@        print("    offset [ %.8g %.8g %.8g ]" % (round(offset[0],7), round(offset[1],7), round(offset[2],7)))@\\
-\mbox{}\verb@        print("    rotation", cbf.get_axis_rotation(cur_axis))@\\
-\mbox{}\verb@        print("    rotation_axis", cbf.get_axis_rotation_axis(cur_axis))@\\
-\mbox{}\verb@        cur_axis = cbf.get_axis_depends_on(cur_axis)@\\
+\mbox{}\verb@        for index in range(count):@\\
+\mbox{}\verb@            print("axis", cur_axis, "index: ", index, file=f)@\\
+\mbox{}\verb@            print("    equipment", cbf.get_axis_equipment(cur_axis), file=f)@\\
+\mbox{}\verb@            print("    depends_on", cbf.get_axis_depends_on(cur_axis), file=f)@\\
+\mbox{}\verb@            print("    equipment_component", cbf.get_axis_equipment_component(cur_axis), file=f)@\\
+\mbox{}\verb@            vector = cbf.get_axis_vector(cur_axis)@\\
+\mbox{}\verb@            print("    vector [ %.8g %.8g %.8g ]" % (round(vector[0],7), round(vector[1],7), round(vector[2],7)), file=f)@\\
+\mbox{}\verb@            offset = cbf.get_axis_offset(cur_axis)@\\
+\mbox{}\verb@            print("    offset [ %.8g %.8g %.8g ]" % (round(offset[0],7), round(offset[1],7), round(offset[2],7)), file=f)@\\
+\mbox{}\verb@            print("    rotation", cbf.get_axis_rotation(cur_axis), file=f)@\\
+\mbox{}\verb@            print("    rotation_axis", cbf.get_axis_rotation_axis(cur_axis), file=f)@\\
+\mbox{}\verb@            cur_axis = cbf.get_axis_depends_on(cur_axis)@\\
 \mbox{}\verb@@{\NWsep}
 \end{list}
 \vspace{-1.5ex}

--- a/pycbf/pycbf.tex
+++ b/pycbf/pycbf.tex
@@ -4621,10 +4621,7 @@ when you build CBFlib, hence that file is hardwired in.
 \mbox{}\verb@                typeofvalue=object.get_typeofvalue()@\\
 \mbox{}\verb@                print("type:",typeofvalue,file=f)@\\
 \mbox{}\verb@                if typeofvalue.find(b"bnry") > -1:@\\
-\mbox{}\verb@                    print("Found the binary!!", end=' ', file=f)@\\
 \mbox{}\verb@                    s=object.get_integerarray_as_string()@\\
-\mbox{}\verb@                    print(type(str(s)), file=f)@\\
-\mbox{}\verb@                    print(dir(str(s)), file=f)@\\
 \mbox{}\verb@                    print(len(s), file=f)@\\
 \mbox{}\verb@                    try:@\\
 \mbox{}\verb@                       import numpy@\\
@@ -4645,7 +4642,6 @@ when you build CBFlib, hence that file is hardwired in.
 \mbox{}\verb@        print(file=f)@\\
 \mbox{}\verb@    del(object)@\\
 \mbox{}\verb@    #@\\
-\mbox{}\verb@    print(dir(), file=f)@\\
 \mbox{}\verb@    #object.free_handle(handle)@\\
 \mbox{}\verb@@{\NWsep}
 \end{list}
@@ -4795,10 +4791,7 @@ It appears to work - eventually. Surprising
 \mbox{}\verb@                typeofvalue=object.get_typeofvalue()@\\
 \mbox{}\verb@                print("type:",typeofvalue,file=f)@\\
 \mbox{}\verb@                if typeofvalue.find(b"bnry") > -1:@\\
-\mbox{}\verb@                    print("Found the binary!!",end=' ',file=f)@\\
 \mbox{}\verb@                    s=object.get_integerarray_as_string()@\\
-\mbox{}\verb@                    print(type(s), file=f)@\\
-\mbox{}\verb@                    print(dir(s), file=f)@\\
 \mbox{}\verb@                    print(len(s), file=f)@\\
 \mbox{}\verb@                    (compression, binaryid, elsize, elsigned, \@\\
 \mbox{}\verb@                        elunsigned, elements, minelement, maxelement, \@\\
@@ -4848,7 +4841,6 @@ It appears to work - eventually. Surprising
 \mbox{}\verb@    newobject.write_widefile(argv[3].encode(),pycbf.CBF,\@\\
 \mbox{}\verb@        pycbf.MIME_HEADERS|pycbf.MSG_DIGEST|pycbf.PAD_4K,0)@\\
 \mbox{}\verb@    #@\\
-\mbox{}\verb@    print(dir(), file=f)@\\
 \mbox{}\verb@    #object.free_handle(handle)@\\
 \mbox{}\verb@@{\NWsep}
 \end{list}

--- a/pycbf/pycbf.w
+++ b/pycbf/pycbf.w
@@ -432,73 +432,74 @@ It appeared to work with the file img2cif\_packed.cif which is built
 when you build CBFlib, hence that file is hardwired in.
 
 @o pycbf_test1.py -i -t
-@{
+@{from sys import argv
+
 import pycbf
 object = pycbf.cbf_handle_struct() # FIXME
-object.read_file(b"../img2cif_packed.cif",pycbf.MSG_DIGEST)
+object.read_file(argv[1].encode(),pycbf.MSG_DIGEST)
 object.rewind_datablock()
-print("Found",object.count_datablocks(),"blocks")
-object.select_datablock(0)
-print("Zeroth is named",object.datablock_name())
-object.rewind_category()
-categories = object.count_categories()
-for i in range(categories):
-    print("Category:",i, end=' ')
-    object.select_category(i)
-    category_name = object.category_name()
-    print("Name:",category_name, end=' ')
-    rows=object.count_rows()
-    print("Rows:",rows, end=' ')
-    cols = object.count_columns()
-    print("Cols:",cols)
-    loop=1
-    object.rewind_column()
-    while loop==1:
-        column_name = object.column_name()
-        print("column name \"",column_name,"\"", end=' ')
-        try:
-           object.next_column()
-        except:
-           break
-    print
-    for j in range(rows):
-        object.select_row(j)
+with open(argv[2],'w',newline='\n') as f:
+    print("Found",object.count_datablocks(),"blocks",file=f)
+    object.select_datablock(0)
+    print("Zeroth is named",object.datablock_name(),file=f)
+    object.rewind_category()
+    categories = object.count_categories()
+    for i in range(categories):
+        print("Category:",i, end=' ', file=f)
+        object.select_category(i)
+        category_name = object.category_name()
+        print("Name:",category_name, end=' ', file=f)
+        rows=object.count_rows()
+        print("Rows:",rows, end=' ', file=f)
+        cols = object.count_columns()
+        print("Cols:",cols,file=f)
+        loop=1
         object.rewind_column()
-        if j==0: print()
-        print("row:",j)
-        for k in range(cols):
-            name=object.column_name()
-            print("col:",name, end=' ')
-            object.select_column(k)
-            typeofvalue=object.get_typeofvalue()
-            print("type:",typeofvalue)
-            if typeofvalue.find(b"bnry") > -1:
-                print("Found the binary!!", end=' ')
-                s=object.get_integerarray_as_string()
-                print(type(str(s)))
-                print(dir(str(s)))
-                print(len(s))
-                try:
-                   import numpy 
-                   d = numpy.frombuffer(bytes(s),numpy.uint32)
-                   # Hard wired Unsigned Int32
-                   print(d.shape)
-                   print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1])
-                   print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)])
-                   d=numpy.reshape(d,(2300,2300))
-#                   from matplotlib import pylab
-#                   pylab.imshow(d,vmin=0,vmax=1000)
-#                   pylab.show()
-                except ImportError:
-                   print("You need to get numpy and matplotlib to see the data")
-            else:
-                value=object.get_value()
-                print("Val:",value,i)
-    print()
-del(object)
-#
-print(dir())
-#object.free_handle(handle)
+        while loop==1:
+            column_name = object.column_name()
+            print("column name \"",column_name,"\"", end=' ', file=f)
+            try:
+               object.next_column()
+            except:
+               break
+        for j in range(rows):
+            object.select_row(j)
+            object.rewind_column()
+            if j==0: print(file=f)
+            print("row:",j,file=f)
+            for k in range(cols):
+                name=object.column_name()
+                print("col:",name, end=' ', file=f)
+                object.select_column(k)
+                typeofvalue=object.get_typeofvalue()
+                print("type:",typeofvalue,file=f)
+                if typeofvalue.find(b"bnry") > -1:
+                    print("Found the binary!!", end=' ', file=f)
+                    s=object.get_integerarray_as_string()
+                    print(type(str(s)), file=f)
+                    print(dir(str(s)), file=f)
+                    print(len(s), file=f)
+                    try:
+                       import numpy
+                       d = numpy.frombuffer(bytes(s),numpy.uint32)
+                       # Hard wired Unsigned Int32
+                       print(d.shape, file=f)
+                       print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1],file=f)
+                       print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)], file=f)
+                       d=numpy.reshape(d,(2300,2300))
+    #                   from matplotlib import pylab
+    #                   pylab.imshow(d,vmin=0,vmax=1000)
+    #                   pylab.show()
+                    except ImportError:
+                       print("You need to get numpy and matplotlib to see the data", file=f)
+                else:
+                    value=object.get_value()
+                    print("Val:",value,i,file=f)
+        print(file=f)
+    del(object)
+    #
+    print(dir(), file=f)
+    #object.free_handle(handle)
 @}
 
 
@@ -513,18 +514,20 @@ for apparent existence of
 a single member function.
 
 @o pycbf_test2.py -i -t
-@{
+@{from sys import argv
+
 import pycbf
 obj = pycbf.cbf_handle_struct()
-obj.read_file(b"../adscconverted.cbf",0)
+obj.read_file(argv[1].encode(),0)
 obj.select_datablock(0)
 g = obj.construct_goniometer()
-print("Rotation axis is",g.get_rotation_axis())
-d = obj.construct_detector(0)
-print("Beam center is",d.get_beam_center())
-print("Detector slow axis is", d.get_detector_axis_slow())
-print("Detector fast axis is", d.get_detector_axis_fast())
-print("Detector axes (fast, slow) are", d.get_detector_axes_fs())
+with open(argv[2],'w',newline='\n') as f:
+    print("Rotation axis is",g.get_rotation_axis(),file=f)
+    d = obj.construct_detector(0)
+    print("Beam center is",d.get_beam_center(),file=f)
+    print("Detector slow axis is", d.get_detector_axis_slow(), file=f)
+    print("Detector fast axis is", d.get_detector_axis_fast(), file=f)
+    print("Detector axes (fast, slow) are", d.get_detector_axes_fs(), file=f)
 @}
 
 
@@ -533,8 +536,7 @@ It appears to work - eventually. Surprising
 \subsection{Test cases for the generics}
 
 @o pycbf_test3.py -i -t
-@{
-import pycbf, unittest
+@{import pycbf, unittest
 class GenericTests(unittest.TestCase):
 
     def test_get_local_integer_byte_order(self):
@@ -558,123 +560,123 @@ class GenericTests(unittest.TestCase):
                            24.0)
 if __name__=="__main__":
     unittest.main()
-
 @}
 
 
 \subsection{Version of pycbf_test1 with write logic added}
 
 @o pycbf_test4.py -i -t
-@{
+@{from sys import argv
+
 # version of pycbf_test1 with write logic added
 import pycbf
 object = pycbf.cbf_handle_struct()
 newobject = pycbf.cbf_handle_struct()
-object.read_file(b"../img2cif_packed.cif",pycbf.MSG_DIGEST)
+object.read_file(argv[1].encode(),pycbf.MSG_DIGEST)
 object.rewind_datablock()
-print("Found",object.count_datablocks(),"blocks")
-object.select_datablock(0)
-print("Zeroth is named",object.datablock_name())
-newobject.force_new_datablock(object.datablock_name());
-object.rewind_category()
-categories = object.count_categories()
-for i in range(categories):
-    print("Category:",i, end= ' ')
-    object.select_category(i)
-    category_name = object.category_name()
-    print("Name:",category_name, end=' ')
-    newobject.new_category(category_name)
-    rows=object.count_rows()
-    print("Rows:",rows, end=' ')
-    cols = object.count_columns()
-    print("Cols:",cols)
-    loop=1
-    object.rewind_column()
-    while loop==1:
-        column_name = object.column_name()
-        print("column name \"",column_name,"\"", end=' ')
-        newobject.new_column(column_name)
-        try:
-           object.next_column()
-        except:
-            break
-    print()
-    for j in range(rows):
-        object.select_row(j)
-        newobject.new_row()
+with open(argv[2],'w',newline='\n') as f:
+    print("Found",object.count_datablocks(),"blocks",file=f)
+    object.select_datablock(0)
+    print("Zeroth is named",object.datablock_name(),file=f)
+    newobject.force_new_datablock(object.datablock_name());
+    object.rewind_category()
+    categories = object.count_categories()
+    for i in range(categories):
+        print("Category:",i, end= ' ', file=f)
+        object.select_category(i)
+        category_name = object.category_name()
+        print("Name:",category_name, end=' ', file=f)
+        newobject.new_category(category_name)
+        rows=object.count_rows()
+        print("Rows:",rows, end=' ', file=f)
+        cols = object.count_columns()
+        print("Cols:",cols,file=f)
+        loop=1
         object.rewind_column()
-        print("row:",j)
-        for k in range(cols):
-            name=object.column_name()
-            print("col:",name, end=' ')
-            object.select_column(k)
-            newobject.select_column(k)
-            typeofvalue=object.get_typeofvalue()
-            print("type:",typeofvalue)
-            if typeofvalue.find(b"bnry") > -1:
-                print("Found the binary!!",end=' ')
-                s=object.get_integerarray_as_string()
-                print(type(s))
-                print(dir(s))
-                print(len(s))
-                (compression, binaryid, elsize, elsigned, \
-                    elunsigned, elements, minelement, maxelement, \
-                    byteorder,dimfast,dimmid,dimslow,padding) = \
-                    object.get_integerarrayparameters_wdims_fs()
-                if dimfast==0:
-                    dimfast = 1
-                if dimmid==0:
-                    dimmid = 1
-                if dimslow == 0:
-                    dimslow = 1
-                print("compression: ",compression)
-                print("binaryid", binaryid)
-                print("elsize", elsize)
-                print("elsigned", elsigned)
-                print("elunsigned",elunsigned)
-                print("elements", elements)
-                print("minelement", minelement)
-                print("maxelement", maxelement)
-                print("byteorder", byteorder)
-                print("dimfast", dimfast)
-                print("dimmid", dimmid)
-                print("dimslow",dimslow)
-                print("padding", padding)
-                newobject.set_integerarray_wdims_fs(\
-                  pycbf.CBF_BYTE_OFFSET,binaryid,s,elsize,elsigned,\
-                  elements,byteorder,dimfast,dimmid,dimslow,padding)
-                try:
-                   import numpy
-                   d = numpy.frombuffer(s,numpy.uint32)
-                   # Hard wired Unsigned Int32
-                   print(d.shape)
-                   print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1])
-                   print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)])
-                   d=numpy.reshape(d,(2300,2300))
-#                   from matplotlib import pylab
-#                   pylab.imshow(d,vmin=0,vmax=1000)
-#                   pylab.show()
-                except ImportError:
-                   print("You need to get numpy and matplotlib to see the data")
-            else:
-                value=object.get_value()
-                newobject.set_value(value)
-                print("Val:",value,i)
-    print()
-del(object)
-newobject.write_widefile(b"newtest1.cbf",pycbf.CBF,\
-    pycbf.MIME_HEADERS|pycbf.MSG_DIGEST|pycbf.PAD_4K,0)
-#
-print(dir())
-#object.free_handle(handle)
+        while loop==1:
+            column_name = object.column_name()
+            print("column name \"",column_name,"\"", end=' ', file=f)
+            newobject.new_column(column_name)
+            try:
+               object.next_column()
+            except:
+                break
+        print(file=f)
+        for j in range(rows):
+            object.select_row(j)
+            newobject.new_row()
+            object.rewind_column()
+            print("row:",j,file=f)
+            for k in range(cols):
+                name=object.column_name()
+                print("col:",name, end=' ', file=f)
+                object.select_column(k)
+                newobject.select_column(k)
+                typeofvalue=object.get_typeofvalue()
+                print("type:",typeofvalue,file=f)
+                if typeofvalue.find(b"bnry") > -1:
+                    print("Found the binary!!",end=' ',file=f)
+                    s=object.get_integerarray_as_string()
+                    print(type(s), file=f)
+                    print(dir(s), file=f)
+                    print(len(s), file=f)
+                    (compression, binaryid, elsize, elsigned, \
+                        elunsigned, elements, minelement, maxelement, \
+                        byteorder,dimfast,dimmid,dimslow,padding) = \
+                        object.get_integerarrayparameters_wdims_fs()
+                    if dimfast==0:
+                        dimfast = 1
+                    if dimmid==0:
+                        dimmid = 1
+                    if dimslow == 0:
+                        dimslow = 1
+                    print("compression: ",compression,file=f)
+                    print("binaryid", binaryid, file=f)
+                    print("elsize", elsize, file=f)
+                    print("elsigned", elsigned, file=f)
+                    print("elunsigned",elunsigned,file=f)
+                    print("elements", elements, file=f)
+                    print("minelement", minelement, file=f)
+                    print("maxelement", maxelement, file=f)
+                    print("byteorder", byteorder, file=f)
+                    print("dimfast", dimfast, file=f)
+                    print("dimmid", dimmid, file=f)
+                    print("dimslow",dimslow,file=f)
+                    print("padding", padding, file=f)
+                    newobject.set_integerarray_wdims_fs(\
+                      pycbf.CBF_BYTE_OFFSET,binaryid,s,elsize,elsigned,\
+                      elements,byteorder,dimfast,dimmid,dimslow,padding)
+                    try:
+                       import numpy
+                       d = numpy.frombuffer(s,numpy.uint32)
+                       # Hard wired Unsigned Int32
+                       print(d.shape, file=f)
+                       print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1],file=f)
+                       print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)], file=f)
+                       d=numpy.reshape(d,(2300,2300))
+    #                   from matplotlib import pylab
+    #                   pylab.imshow(d,vmin=0,vmax=1000)
+    #                   pylab.show()
+                    except ImportError:
+                       print("You need to get numpy and matplotlib to see the data", file=f)
+                else:
+                    value=object.get_value()
+                    newobject.set_value(value)
+                    print("Val:",value,i,file=f)
+        print(file=f)
+    del(object)
+    newobject.write_widefile(argv[3].encode(),pycbf.CBF,\
+        pycbf.MIME_HEADERS|pycbf.MSG_DIGEST|pycbf.PAD_4K,0)
+    #
+    print(dir(), file=f)
+    #object.free_handle(handle)
 @}
 
 
 \subsection{Processing of XFEL axes}
 
 @o pycbf_testfelaxes.py -i -t
-@{
-import pycbf, sys
+@{import pycbf, sys
 from decimal import Decimal, ROUND_HALF_UP
 
 image_file = bytes(sys.argv[1],'utf-8')
@@ -682,41 +684,42 @@ image_file = bytes(sys.argv[1],'utf-8')
 cbf = pycbf.cbf_handle_struct()
 cbf.read_widefile(image_file, pycbf.MSG_DIGEST)
 
-for element in range(64):
-    d = cbf.construct_detector(element)
-    print("element:", element)
+with open(sys.argv[2],'w',newline='\n') as f:
+    for element in range(64):
+        d = cbf.construct_detector(element)
+        print("element:", element, file=f)
 
-    v00 = d.get_pixel_coordinates(0, 0)
-    v01 = d.get_pixel_coordinates(0, 1)
-    v10 = d.get_pixel_coordinates(1, 0)
-    v11 = d.get_pixel_coordinates(1, 1)
-    prec = Decimal('1.000000000')
+        v00 = d.get_pixel_coordinates(0, 0)
+        v01 = d.get_pixel_coordinates(0, 1)
+        v10 = d.get_pixel_coordinates(1, 0)
+        v11 = d.get_pixel_coordinates(1, 1)
+        prec = Decimal('1.000000000')
 
-    print('(0, 0) v00 [ %.9f %.9f %.9f ]' %(round(v00[0],9), round(v00[1],9), round(v00[2],9)))
-    print('(0, 1) v01 [ %.9g %.9g %.9g ]' %(round(v01[0],9), round(v01[1],9), round(v01[2],9)))
-    print('(1, 0) v10 [ %.9g %.9g %.9g ]' %(round(v10[0],9), round(v10[1],9), round(v10[2],9)))
-    print('(1, 1) v11 [ %.9g %.9g %.9g ]' %(round(v11[0],9), round(v11[1],9), round(v11[2],9)))
+        print('(0, 0) v00 [ %.9f %.9f %.9f ]' %(round(v00[0],9), round(v00[1],9), round(v00[2],9)), file=f)
+        print('(0, 1) v01 [ %.9g %.9g %.9g ]' %(round(v01[0],9), round(v01[1],9), round(v01[2],9)), file=f)
+        print('(1, 0) v10 [ %.9g %.9g %.9g ]' %(round(v10[0],9), round(v10[1],9), round(v10[2],9)), file=f)
+        print('(1, 1) v11 [ %.9g %.9g %.9g ]' %(round(v11[0],9), round(v11[1],9), round(v11[2],9)), file=f)
 
-    print("surface axes:",  d.get_detector_surface_axes(0), d.get_detector_surface_axes(1))
+        print("surface axes:",  d.get_detector_surface_axes(0), d.get_detector_surface_axes(1), file=f)
 
-    print(d.get_detector_surface_axes(0), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(0)), "ancestors")
-    print(d.get_detector_surface_axes(1), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(1)), "ancestors")
+        print(d.get_detector_surface_axes(0), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(0)), "ancestors", file=f)
+        print(d.get_detector_surface_axes(1), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(1)), "ancestors", file=f)
 
-    cur_axis = d.get_detector_surface_axes(0)
-    count = cbf.count_axis_ancestors(cur_axis)
+        cur_axis = d.get_detector_surface_axes(0)
+        count = cbf.count_axis_ancestors(cur_axis)
 
-    for index in range(count):
-        print("axis", cur_axis, "index: ", index)
-        print("    equipment", cbf.get_axis_equipment(cur_axis))
-        print("    depends_on", cbf.get_axis_depends_on(cur_axis))
-        print("    equipment_component", cbf.get_axis_equipment_component(cur_axis))
-        vector = cbf.get_axis_vector(cur_axis)
-        print("    vector [ %.8g %.8g %.8g ]" % (round(vector[0],7), round(vector[1],7), round(vector[2],7)))
-        offset = cbf.get_axis_offset(cur_axis)
-        print("    offset [ %.8g %.8g %.8g ]" % (round(offset[0],7), round(offset[1],7), round(offset[2],7)))
-        print("    rotation", cbf.get_axis_rotation(cur_axis))
-        print("    rotation_axis", cbf.get_axis_rotation_axis(cur_axis))
-        cur_axis = cbf.get_axis_depends_on(cur_axis)
+        for index in range(count):
+            print("axis", cur_axis, "index: ", index, file=f)
+            print("    equipment", cbf.get_axis_equipment(cur_axis), file=f)
+            print("    depends_on", cbf.get_axis_depends_on(cur_axis), file=f)
+            print("    equipment_component", cbf.get_axis_equipment_component(cur_axis), file=f)
+            vector = cbf.get_axis_vector(cur_axis)
+            print("    vector [ %.8g %.8g %.8g ]" % (round(vector[0],7), round(vector[1],7), round(vector[2],7)), file=f)
+            offset = cbf.get_axis_offset(cur_axis)
+            print("    offset [ %.8g %.8g %.8g ]" % (round(offset[0],7), round(offset[1],7), round(offset[2],7)), file=f)
+            print("    rotation", cbf.get_axis_rotation(cur_axis), file=f)
+            print("    rotation_axis", cbf.get_axis_rotation_axis(cur_axis), file=f)
+            cur_axis = cbf.get_axis_depends_on(cur_axis)
 @}
 
 \section{Worked example 1 : xmas beamline + mar ccd detector at the ESRF}

--- a/pycbf/pycbf.w
+++ b/pycbf/pycbf.w
@@ -474,10 +474,7 @@ with open(argv[2],'w',newline='\n') as f:
                 typeofvalue=object.get_typeofvalue()
                 print("type:",typeofvalue,file=f)
                 if typeofvalue.find(b"bnry") > -1:
-                    print("Found the binary!!", end=' ', file=f)
                     s=object.get_integerarray_as_string()
-                    print(type(str(s)), file=f)
-                    print(dir(str(s)), file=f)
                     print(len(s), file=f)
                     try:
                        import numpy
@@ -498,7 +495,6 @@ with open(argv[2],'w',newline='\n') as f:
         print(file=f)
     del(object)
     #
-    print(dir(), file=f)
     #object.free_handle(handle)
 @}
 
@@ -615,10 +611,7 @@ with open(argv[2],'w',newline='\n') as f:
                 typeofvalue=object.get_typeofvalue()
                 print("type:",typeofvalue,file=f)
                 if typeofvalue.find(b"bnry") > -1:
-                    print("Found the binary!!",end=' ',file=f)
                     s=object.get_integerarray_as_string()
-                    print(type(s), file=f)
-                    print(dir(s), file=f)
                     print(len(s), file=f)
                     (compression, binaryid, elsize, elsigned, \
                         elunsigned, elements, minelement, maxelement, \
@@ -668,7 +661,6 @@ with open(argv[2],'w',newline='\n') as f:
     newobject.write_widefile(argv[3].encode(),pycbf.CBF,\
         pycbf.MIME_HEADERS|pycbf.MSG_DIGEST|pycbf.PAD_4K,0)
     #
-    print(dir(), file=f)
     #object.free_handle(handle)
 @}
 

--- a/pycbf/pycbf_test1.py
+++ b/pycbf/pycbf_test1.py
@@ -1,67 +1,68 @@
+from sys import argv
 
 import pycbf
 object = pycbf.cbf_handle_struct() # FIXME
-object.read_file(b"../img2cif_packed.cif",pycbf.MSG_DIGEST)
+object.read_file(argv[1].encode(),pycbf.MSG_DIGEST)
 object.rewind_datablock()
-print("Found",object.count_datablocks(),"blocks")
-object.select_datablock(0)
-print("Zeroth is named",object.datablock_name())
-object.rewind_category()
-categories = object.count_categories()
-for i in range(categories):
-    print("Category:",i, end=' ')
-    object.select_category(i)
-    category_name = object.category_name()
-    print("Name:",category_name, end=' ')
-    rows=object.count_rows()
-    print("Rows:",rows, end=' ')
-    cols = object.count_columns()
-    print("Cols:",cols)
-    loop=1
-    object.rewind_column()
-    while loop==1:
-        column_name = object.column_name()
-        print("column name \"",column_name,"\"", end=' ')
-        try:
-           object.next_column()
-        except:
-           break
-    print
-    for j in range(rows):
-        object.select_row(j)
+with open(argv[2],'w',newline='\n') as f:
+    print("Found",object.count_datablocks(),"blocks",file=f)
+    object.select_datablock(0)
+    print("Zeroth is named",object.datablock_name(),file=f)
+    object.rewind_category()
+    categories = object.count_categories()
+    for i in range(categories):
+        print("Category:",i, end=' ', file=f)
+        object.select_category(i)
+        category_name = object.category_name()
+        print("Name:",category_name, end=' ', file=f)
+        rows=object.count_rows()
+        print("Rows:",rows, end=' ', file=f)
+        cols = object.count_columns()
+        print("Cols:",cols,file=f)
+        loop=1
         object.rewind_column()
-        if j==0: print()
-        print("row:",j)
-        for k in range(cols):
-            name=object.column_name()
-            print("col:",name, end=' ')
-            object.select_column(k)
-            typeofvalue=object.get_typeofvalue()
-            print("type:",typeofvalue)
-            if typeofvalue.find(b"bnry") > -1:
-                print("Found the binary!!", end=' ')
-                s=object.get_integerarray_as_string()
-                print(type(str(s)))
-                print(dir(str(s)))
-                print(len(s))
-                try:
-                   import numpy 
-                   d = numpy.frombuffer(bytes(s),numpy.uint32)
-                   # Hard wired Unsigned Int32
-                   print(d.shape)
-                   print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1])
-                   print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)])
-                   d=numpy.reshape(d,(2300,2300))
-#                   from matplotlib import pylab
-#                   pylab.imshow(d,vmin=0,vmax=1000)
-#                   pylab.show()
-                except ImportError:
-                   print("You need to get numpy and matplotlib to see the data")
-            else:
-                value=object.get_value()
-                print("Val:",value,i)
-    print()
-del(object)
-#
-print(dir())
-#object.free_handle(handle)
+        while loop==1:
+            column_name = object.column_name()
+            print("column name \"",column_name,"\"", end=' ', file=f)
+            try:
+               object.next_column()
+            except:
+               break
+        for j in range(rows):
+            object.select_row(j)
+            object.rewind_column()
+            if j==0: print(file=f)
+            print("row:",j,file=f)
+            for k in range(cols):
+                name=object.column_name()
+                print("col:",name, end=' ', file=f)
+                object.select_column(k)
+                typeofvalue=object.get_typeofvalue()
+                print("type:",typeofvalue,file=f)
+                if typeofvalue.find(b"bnry") > -1:
+                    print("Found the binary!!", end=' ', file=f)
+                    s=object.get_integerarray_as_string()
+                    print(type(str(s)), file=f)
+                    print(dir(str(s)), file=f)
+                    print(len(s), file=f)
+                    try:
+                       import numpy
+                       d = numpy.frombuffer(bytes(s),numpy.uint32)
+                       # Hard wired Unsigned Int32
+                       print(d.shape, file=f)
+                       print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1],file=f)
+                       print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)], file=f)
+                       d=numpy.reshape(d,(2300,2300))
+    #                   from matplotlib import pylab
+    #                   pylab.imshow(d,vmin=0,vmax=1000)
+    #                   pylab.show()
+                    except ImportError:
+                       print("You need to get numpy and matplotlib to see the data", file=f)
+                else:
+                    value=object.get_value()
+                    print("Val:",value,i,file=f)
+        print(file=f)
+    del(object)
+    #
+    print(dir(), file=f)
+    #object.free_handle(handle)

--- a/pycbf/pycbf_test1.py
+++ b/pycbf/pycbf_test1.py
@@ -40,10 +40,7 @@ with open(argv[2],'w',newline='\n') as f:
                 typeofvalue=object.get_typeofvalue()
                 print("type:",typeofvalue,file=f)
                 if typeofvalue.find(b"bnry") > -1:
-                    print("Found the binary!!", end=' ', file=f)
                     s=object.get_integerarray_as_string()
-                    print(type(str(s)), file=f)
-                    print(dir(str(s)), file=f)
                     print(len(s), file=f)
                     try:
                        import numpy
@@ -64,5 +61,4 @@ with open(argv[2],'w',newline='\n') as f:
         print(file=f)
     del(object)
     #
-    print(dir(), file=f)
     #object.free_handle(handle)

--- a/pycbf/pycbf_test2.py
+++ b/pycbf/pycbf_test2.py
@@ -1,12 +1,14 @@
+from sys import argv
 
 import pycbf
 obj = pycbf.cbf_handle_struct()
-obj.read_file(b"../adscconverted.cbf",0)
+obj.read_file(argv[1].encode(),0)
 obj.select_datablock(0)
 g = obj.construct_goniometer()
-print("Rotation axis is",g.get_rotation_axis())
-d = obj.construct_detector(0)
-print("Beam center is",d.get_beam_center())
-print("Detector slow axis is", d.get_detector_axis_slow())
-print("Detector fast axis is", d.get_detector_axis_fast())
-print("Detector axes (fast, slow) are", d.get_detector_axes_fs())
+with open(argv[2],'w',newline='\n') as f:
+    print("Rotation axis is",g.get_rotation_axis(),file=f)
+    d = obj.construct_detector(0)
+    print("Beam center is",d.get_beam_center(),file=f)
+    print("Detector slow axis is", d.get_detector_axis_slow(), file=f)
+    print("Detector fast axis is", d.get_detector_axis_fast(), file=f)
+    print("Detector axes (fast, slow) are", d.get_detector_axes_fs(), file=f)

--- a/pycbf/pycbf_test3.py
+++ b/pycbf/pycbf_test3.py
@@ -1,4 +1,3 @@
-
 import pycbf, unittest
 class GenericTests(unittest.TestCase):
 
@@ -23,4 +22,3 @@ class GenericTests(unittest.TestCase):
                            24.0)
 if __name__=="__main__":
     unittest.main()
-

--- a/pycbf/pycbf_test4.py
+++ b/pycbf/pycbf_test4.py
@@ -1,102 +1,104 @@
+from sys import argv
 
 # version of pycbf_test1 with write logic added
 import pycbf
 object = pycbf.cbf_handle_struct()
 newobject = pycbf.cbf_handle_struct()
-object.read_file(b"../img2cif_packed.cif",pycbf.MSG_DIGEST)
+object.read_file(argv[1].encode(),pycbf.MSG_DIGEST)
 object.rewind_datablock()
-print("Found",object.count_datablocks(),"blocks")
-object.select_datablock(0)
-print("Zeroth is named",object.datablock_name())
-newobject.force_new_datablock(object.datablock_name());
-object.rewind_category()
-categories = object.count_categories()
-for i in range(categories):
-    print("Category:",i, end= ' ')
-    object.select_category(i)
-    category_name = object.category_name()
-    print("Name:",category_name, end=' ')
-    newobject.new_category(category_name)
-    rows=object.count_rows()
-    print("Rows:",rows, end=' ')
-    cols = object.count_columns()
-    print("Cols:",cols)
-    loop=1
-    object.rewind_column()
-    while loop==1:
-        column_name = object.column_name()
-        print("column name \"",column_name,"\"", end=' ')
-        newobject.new_column(column_name)
-        try:
-           object.next_column()
-        except:
-            break
-    print()
-    for j in range(rows):
-        object.select_row(j)
-        newobject.new_row()
+with open(argv[2],'w',newline='\n') as f:
+    print("Found",object.count_datablocks(),"blocks",file=f)
+    object.select_datablock(0)
+    print("Zeroth is named",object.datablock_name(),file=f)
+    newobject.force_new_datablock(object.datablock_name());
+    object.rewind_category()
+    categories = object.count_categories()
+    for i in range(categories):
+        print("Category:",i, end= ' ', file=f)
+        object.select_category(i)
+        category_name = object.category_name()
+        print("Name:",category_name, end=' ', file=f)
+        newobject.new_category(category_name)
+        rows=object.count_rows()
+        print("Rows:",rows, end=' ', file=f)
+        cols = object.count_columns()
+        print("Cols:",cols,file=f)
+        loop=1
         object.rewind_column()
-        print("row:",j)
-        for k in range(cols):
-            name=object.column_name()
-            print("col:",name, end=' ')
-            object.select_column(k)
-            newobject.select_column(k)
-            typeofvalue=object.get_typeofvalue()
-            print("type:",typeofvalue)
-            if typeofvalue.find(b"bnry") > -1:
-                print("Found the binary!!",end=' ')
-                s=object.get_integerarray_as_string()
-                print(type(s))
-                print(dir(s))
-                print(len(s))
-                (compression, binaryid, elsize, elsigned, \
-                    elunsigned, elements, minelement, maxelement, \
-                    byteorder,dimfast,dimmid,dimslow,padding) = \
-                    object.get_integerarrayparameters_wdims_fs()
-                if dimfast==0:
-                    dimfast = 1
-                if dimmid==0:
-                    dimmid = 1
-                if dimslow == 0:
-                    dimslow = 1
-                print("compression: ",compression)
-                print("binaryid", binaryid)
-                print("elsize", elsize)
-                print("elsigned", elsigned)
-                print("elunsigned",elunsigned)
-                print("elements", elements)
-                print("minelement", minelement)
-                print("maxelement", maxelement)
-                print("byteorder", byteorder)
-                print("dimfast", dimfast)
-                print("dimmid", dimmid)
-                print("dimslow",dimslow)
-                print("padding", padding)
-                newobject.set_integerarray_wdims_fs(\
-                  pycbf.CBF_BYTE_OFFSET,binaryid,s,elsize,elsigned,\
-                  elements,byteorder,dimfast,dimmid,dimslow,padding)
-                try:
-                   import numpy
-                   d = numpy.frombuffer(s,numpy.uint32)
-                   # Hard wired Unsigned Int32
-                   print(d.shape)
-                   print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1])
-                   print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)])
-                   d=numpy.reshape(d,(2300,2300))
-#                   from matplotlib import pylab
-#                   pylab.imshow(d,vmin=0,vmax=1000)
-#                   pylab.show()
-                except ImportError:
-                   print("You need to get numpy and matplotlib to see the data")
-            else:
-                value=object.get_value()
-                newobject.set_value(value)
-                print("Val:",value,i)
-    print()
-del(object)
-newobject.write_widefile(b"newtest1.cbf",pycbf.CBF,\
-    pycbf.MIME_HEADERS|pycbf.MSG_DIGEST|pycbf.PAD_4K,0)
-#
-print(dir())
-#object.free_handle(handle)
+        while loop==1:
+            column_name = object.column_name()
+            print("column name \"",column_name,"\"", end=' ', file=f)
+            newobject.new_column(column_name)
+            try:
+               object.next_column()
+            except:
+                break
+        print(file=f)
+        for j in range(rows):
+            object.select_row(j)
+            newobject.new_row()
+            object.rewind_column()
+            print("row:",j,file=f)
+            for k in range(cols):
+                name=object.column_name()
+                print("col:",name, end=' ', file=f)
+                object.select_column(k)
+                newobject.select_column(k)
+                typeofvalue=object.get_typeofvalue()
+                print("type:",typeofvalue,file=f)
+                if typeofvalue.find(b"bnry") > -1:
+                    print("Found the binary!!",end=' ',file=f)
+                    s=object.get_integerarray_as_string()
+                    print(type(s), file=f)
+                    print(dir(s), file=f)
+                    print(len(s), file=f)
+                    (compression, binaryid, elsize, elsigned, \
+                        elunsigned, elements, minelement, maxelement, \
+                        byteorder,dimfast,dimmid,dimslow,padding) = \
+                        object.get_integerarrayparameters_wdims_fs()
+                    if dimfast==0:
+                        dimfast = 1
+                    if dimmid==0:
+                        dimmid = 1
+                    if dimslow == 0:
+                        dimslow = 1
+                    print("compression: ",compression,file=f)
+                    print("binaryid", binaryid, file=f)
+                    print("elsize", elsize, file=f)
+                    print("elsigned", elsigned, file=f)
+                    print("elunsigned",elunsigned,file=f)
+                    print("elements", elements, file=f)
+                    print("minelement", minelement, file=f)
+                    print("maxelement", maxelement, file=f)
+                    print("byteorder", byteorder, file=f)
+                    print("dimfast", dimfast, file=f)
+                    print("dimmid", dimmid, file=f)
+                    print("dimslow",dimslow,file=f)
+                    print("padding", padding, file=f)
+                    newobject.set_integerarray_wdims_fs(\
+                      pycbf.CBF_BYTE_OFFSET,binaryid,s,elsize,elsigned,\
+                      elements,byteorder,dimfast,dimmid,dimslow,padding)
+                    try:
+                       import numpy
+                       d = numpy.frombuffer(s,numpy.uint32)
+                       # Hard wired Unsigned Int32
+                       print(d.shape, file=f)
+                       print(d[0:10],d[int(d.shape[0]/2)],d[len(d)-1],file=f)
+                       print(d[int(d.shape[0]/3):int(d.shape[0]/3+20)], file=f)
+                       d=numpy.reshape(d,(2300,2300))
+    #                   from matplotlib import pylab
+    #                   pylab.imshow(d,vmin=0,vmax=1000)
+    #                   pylab.show()
+                    except ImportError:
+                       print("You need to get numpy and matplotlib to see the data", file=f)
+                else:
+                    value=object.get_value()
+                    newobject.set_value(value)
+                    print("Val:",value,i,file=f)
+        print(file=f)
+    del(object)
+    newobject.write_widefile(argv[3].encode(),pycbf.CBF,\
+        pycbf.MIME_HEADERS|pycbf.MSG_DIGEST|pycbf.PAD_4K,0)
+    #
+    print(dir(), file=f)
+    #object.free_handle(handle)

--- a/pycbf/pycbf_test4.py
+++ b/pycbf/pycbf_test4.py
@@ -47,10 +47,7 @@ with open(argv[2],'w',newline='\n') as f:
                 typeofvalue=object.get_typeofvalue()
                 print("type:",typeofvalue,file=f)
                 if typeofvalue.find(b"bnry") > -1:
-                    print("Found the binary!!",end=' ',file=f)
                     s=object.get_integerarray_as_string()
-                    print(type(s), file=f)
-                    print(dir(s), file=f)
                     print(len(s), file=f)
                     (compression, binaryid, elsize, elsigned, \
                         elunsigned, elements, minelement, maxelement, \
@@ -100,5 +97,4 @@ with open(argv[2],'w',newline='\n') as f:
     newobject.write_widefile(argv[3].encode(),pycbf.CBF,\
         pycbf.MIME_HEADERS|pycbf.MSG_DIGEST|pycbf.PAD_4K,0)
     #
-    print(dir(), file=f)
     #object.free_handle(handle)

--- a/pycbf/pycbf_testfelaxes.py
+++ b/pycbf/pycbf_testfelaxes.py
@@ -1,4 +1,3 @@
-
 import pycbf, sys
 from decimal import Decimal, ROUND_HALF_UP
 
@@ -7,38 +6,39 @@ image_file = bytes(sys.argv[1],'utf-8')
 cbf = pycbf.cbf_handle_struct()
 cbf.read_widefile(image_file, pycbf.MSG_DIGEST)
 
-for element in range(64):
-    d = cbf.construct_detector(element)
-    print("element:", element)
+with open(sys.argv[2],'w',newline='\n') as f:
+    for element in range(64):
+        d = cbf.construct_detector(element)
+        print("element:", element, file=f)
 
-    v00 = d.get_pixel_coordinates(0, 0)
-    v01 = d.get_pixel_coordinates(0, 1)
-    v10 = d.get_pixel_coordinates(1, 0)
-    v11 = d.get_pixel_coordinates(1, 1)
-    prec = Decimal('1.000000000')
+        v00 = d.get_pixel_coordinates(0, 0)
+        v01 = d.get_pixel_coordinates(0, 1)
+        v10 = d.get_pixel_coordinates(1, 0)
+        v11 = d.get_pixel_coordinates(1, 1)
+        prec = Decimal('1.000000000')
 
-    print('(0, 0) v00 [ %.9f %.9f %.9f ]' %(round(v00[0],9), round(v00[1],9), round(v00[2],9)))
-    print('(0, 1) v01 [ %.9g %.9g %.9g ]' %(round(v01[0],9), round(v01[1],9), round(v01[2],9)))
-    print('(1, 0) v10 [ %.9g %.9g %.9g ]' %(round(v10[0],9), round(v10[1],9), round(v10[2],9)))
-    print('(1, 1) v11 [ %.9g %.9g %.9g ]' %(round(v11[0],9), round(v11[1],9), round(v11[2],9)))
+        print('(0, 0) v00 [ %.9f %.9f %.9f ]' %(round(v00[0],9), round(v00[1],9), round(v00[2],9)), file=f)
+        print('(0, 1) v01 [ %.9g %.9g %.9g ]' %(round(v01[0],9), round(v01[1],9), round(v01[2],9)), file=f)
+        print('(1, 0) v10 [ %.9g %.9g %.9g ]' %(round(v10[0],9), round(v10[1],9), round(v10[2],9)), file=f)
+        print('(1, 1) v11 [ %.9g %.9g %.9g ]' %(round(v11[0],9), round(v11[1],9), round(v11[2],9)), file=f)
 
-    print("surface axes:",  d.get_detector_surface_axes(0), d.get_detector_surface_axes(1))
+        print("surface axes:",  d.get_detector_surface_axes(0), d.get_detector_surface_axes(1), file=f)
 
-    print(d.get_detector_surface_axes(0), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(0)), "ancestors")
-    print(d.get_detector_surface_axes(1), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(1)), "ancestors")
+        print(d.get_detector_surface_axes(0), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(0)), "ancestors", file=f)
+        print(d.get_detector_surface_axes(1), "has", cbf.count_axis_ancestors(d.get_detector_surface_axes(1)), "ancestors", file=f)
 
-    cur_axis = d.get_detector_surface_axes(0)
-    count = cbf.count_axis_ancestors(cur_axis)
+        cur_axis = d.get_detector_surface_axes(0)
+        count = cbf.count_axis_ancestors(cur_axis)
 
-    for index in range(count):
-        print("axis", cur_axis, "index: ", index)
-        print("    equipment", cbf.get_axis_equipment(cur_axis))
-        print("    depends_on", cbf.get_axis_depends_on(cur_axis))
-        print("    equipment_component", cbf.get_axis_equipment_component(cur_axis))
-        vector = cbf.get_axis_vector(cur_axis)
-        print("    vector [ %.8g %.8g %.8g ]" % (round(vector[0],7), round(vector[1],7), round(vector[2],7)))
-        offset = cbf.get_axis_offset(cur_axis)
-        print("    offset [ %.8g %.8g %.8g ]" % (round(offset[0],7), round(offset[1],7), round(offset[2],7)))
-        print("    rotation", cbf.get_axis_rotation(cur_axis))
-        print("    rotation_axis", cbf.get_axis_rotation_axis(cur_axis))
-        cur_axis = cbf.get_axis_depends_on(cur_axis)
+        for index in range(count):
+            print("axis", cur_axis, "index: ", index, file=f)
+            print("    equipment", cbf.get_axis_equipment(cur_axis), file=f)
+            print("    depends_on", cbf.get_axis_depends_on(cur_axis), file=f)
+            print("    equipment_component", cbf.get_axis_equipment_component(cur_axis), file=f)
+            vector = cbf.get_axis_vector(cur_axis)
+            print("    vector [ %.8g %.8g %.8g ]" % (round(vector[0],7), round(vector[1],7), round(vector[2],7)), file=f)
+            offset = cbf.get_axis_offset(cur_axis)
+            print("    offset [ %.8g %.8g %.8g ]" % (round(offset[0],7), round(offset[1],7), round(offset[2],7)), file=f)
+            print("    rotation", cbf.get_axis_rotation(cur_axis), file=f)
+            print("    rotation_axis", cbf.get_axis_rotation_axis(cur_axis), file=f)
+            cur_axis = cbf.get_axis_depends_on(cur_axis)


### PR DESCRIPTION
* Does not regenerate the Python 3 tests, but uses the committed `pycbf_test1.py` _et al._
* Suspiciously absent: _ply_ ( `drel_lex.py`, `drel_yacc.py`, `drelc.py`, and `drel_prep.py`) and _pycifrw_.
* Unlike _DIALS_'s `build.py`, this does not compile the C code with `CBF_NO_REGEX`; this may be a Windows thing, yet to be addressed.
* Always builds the module with `SWIG_PYTHON_STRICT_BYTE_CHAR`, which causes it to be multiply defined. Does default Python 3 string handling in SWIG work as intended if they are _all_ removed?
* Does not set `SOVERSION` or `VERSION` on the built Python module.
