### PR TITLE
Update internal HDF5 dependency to 1.14.6 

### DIFF
--- a/.dev/docker/make_tests.dockerfile
+++ b/.dev/docker/make_tests.dockerfile
@@ -5,7 +5,7 @@ RUN mkdir /app
 COPY ./cbflib /app/cbflib
 
 RUN apt-get update && \
-  apt-get install -y build-essential git wget libjpeg-dev m4 automake libpcre2-dev byacc liblzma-dev rsync gfortran libz-dev
+  apt-get install -y bison build-essential git wget libjpeg-dev m4 automake libpcre2-dev liblzma-dev rsync gfortran libz-dev
 
 RUN mkdir -p ~/miniconda3 && \
   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh && \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,8 +454,8 @@ fetchcontent_declare(data_output
     -N -i "${CMAKE_CURRENT_SOURCE_DIR}/patches/cbflib-data-output-${PROJECT_VERSION}.patch" -p 1 -t --binary)
 
 fetchcontent_declare(hdf5
-  URL "http://downloads.sf.net/cbflib/hdf5-1.14.4-2.tar.gz"
-  URL_HASH MD5=1791c5f70660bf4ec2e05fc15526c181)
+  URL "https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz"
+  URL_HASH MD5=63426c8e24086634eaf9179a8c5fe9e5)
 
 fetchcontent_declare(pcreposix
   URL "http://downloads.sf.net/cbflib/pcre-8.38.tar.gz"
@@ -544,16 +544,16 @@ if(CBF_WITH_HDF5)
     "HDF5 configured externally")
   set(HDF_PACKAGE_NAMESPACE "hdf5::" CACHE INTERNAL
     "Name for HDF package namespace (can be empty)")
-  set(LIBAEC_TGZ_NAME "libaec-1.0.6.tar.gz" CACHE INTERNAL
+  set(LIBAEC_TGZ_NAME "libaec-1.1.3.tar.gz" CACHE INTERNAL
     "Use SZIP AEC from compressed file")
   set(LIBAEC_TGZ_ORIGPATH
-    "https://github.com/MathisRosenhauer/libaec/releases/download/v1.0.6"
+    "https://github.com/MathisRosenhauer/libaec/releases/download/v1.1.3"
     CACHE INTERNAL
     "Use LIBAEC from original location")
-  set(ZLIB_TGZ_NAME "zlib-1.3.tar.gz" CACHE INTERNAL
+  set(ZLIB_TGZ_NAME "zlib-1.3.1.tar.gz" CACHE INTERNAL
     "Use HDF5_ZLib from compressed file")
   set(ZLIB_TGZ_ORIGPATH
-    "https://github.com/madler/zlib/releases/download/v1.3"
+    "https://github.com/madler/zlib/releases/download/v1.3.1"
     CACHE INTERNAL
     "Use zlib from original location")
   fetchcontent_makeavailable(hdf5)
@@ -566,15 +566,10 @@ if(CBF_WITH_HDF5)
     set(_hdf5_target hdf5-static)
   endif()
 else()
-  if(NOT BUILD_SHARED_LIBS)
-    # HDF5_USE_STATIC_LIBRARIES does not seem to do what it is
-    # supposed to, see
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/24613.
-    set(HDF5_USE_STATIC_LIBRARIES TRUE)
-  endif()
-  find_package(HDF5 REQUIRED)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(hdf5 REQUIRED IMPORTED_TARGET hdf5>=1.10)
   find_program(_h5dump_executable h5dump REQUIRED)
-  set(_hdf5_target hdf5::hdf5)
+  set(_hdf5_target PkgConfig::hdf5)
 endif()
 
 
@@ -589,6 +584,7 @@ endif()
 
 # CBFlib must be compiled with H5_USE_110_API.  With MSVC, also need
 # H5_BUILT_AS_DYNAMIC_LIB if HDF5 is a dynamic library.
+# target_compile_definitions cannot be used on an ALIAS target.
 add_library(hdf5 ALIAS ${_hdf5_target})
 target_compile_definitions(${_hdf5_target}
   INTERFACE H5_USE_110_API)

--- a/Makefile
+++ b/Makefile
@@ -374,10 +374,8 @@ endif
 
 ifneq ("$(CBFLIB_DONT_USE_LOCAL_HDF5)","yes")
   HDF5_PREFIX ?= $(PWD)
-  HDF5 ?= hdf5-1.14.4-2
-  ifeq ("$(HDF5)","hdf5-1.14.4-2")
-    HDF5CFLAGS=-DH5_USE_110_API
-  endif
+  HDF5 ?= hdf5-1.14.6
+  HDF5CFLAGS=-DH5_USE_110_API
   HDF5dep = $(HDF5)
   HDF5_INSTALL = $(HDF5)_INSTALL
   ifneq ("$(MSYS2)","yes")
@@ -787,7 +785,7 @@ PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
-HDF5_URL	?= http://downloads.sf.net/cbflib/$(HDF5).tar.gz
+HDF5_URL	?= https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/$(HDF5).tar.gz
 ifneq ($(CBFLIB_DONT_USE_LOCAL_NUWEB),yes)
 NUWEB_URL	?= http://downloads.sf.net/cbflib/$(NUWEB_DEP).tar.gz
 endif
@@ -1055,7 +1053,7 @@ default:
 	@echo '   NUWEB_DEP = $(NUWEB_DEP)'
 	@echo '   NUWEB_DEP2 = $(NUWEB_DEP2)'
 	@echo ' '
-	@echo ' You will need either a system HDF5 1.12 or it to be installed here.'
+	@echo ' You will need either a system HDF5 >=1.10 or it to be installed here.'
 	@echo ' Check that CBFLIB_DONT_USE_LOCAL_HDF5 and HDF5 are defined correctly :'
 	@echo ' '
 	@echo ' The current values are:'

--- a/Makefile_LINUX
+++ b/Makefile_LINUX
@@ -374,10 +374,8 @@ endif
 
 ifneq ("$(CBFLIB_DONT_USE_LOCAL_HDF5)","yes")
   HDF5_PREFIX ?= $(PWD)
-  HDF5 ?= hdf5-1.14.4-2
-  ifeq ("$(HDF5)","hdf5-1.14.4-2")
-    HDF5CFLAGS=-DH5_USE_110_API
-  endif
+  HDF5 ?= hdf5-1.14.6
+  HDF5CFLAGS=-DH5_USE_110_API
   HDF5dep = $(HDF5)
   HDF5_INSTALL = $(HDF5)_INSTALL
   ifneq ("$(MSYS2)","yes")
@@ -783,7 +781,7 @@ PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
-HDF5_URL	?= http://downloads.sf.net/cbflib/$(HDF5).tar.gz
+HDF5_URL	?= https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/$(HDF5).tar.gz
 ifneq ($(CBFLIB_DONT_USE_LOCAL_NUWEB),yes)
 NUWEB_URL	?= http://downloads.sf.net/cbflib/$(NUWEB_DEP).tar.gz
 endif
@@ -1051,7 +1049,7 @@ default:
 	@echo '   NUWEB_DEP = $(NUWEB_DEP)'
 	@echo '   NUWEB_DEP2 = $(NUWEB_DEP2)'
 	@echo ' '
-	@echo ' You will need either a system HDF5 1.12 or it to be installed here.'
+	@echo ' You will need either a system HDF5 >=1.10 or it to be installed here.'
 	@echo ' Check that CBFLIB_DONT_USE_LOCAL_HDF5 and HDF5 are defined correctly :'
 	@echo ' '
 	@echo ' The current values are:'

--- a/Makefile_MINGW
+++ b/Makefile_MINGW
@@ -374,10 +374,8 @@ endif
 
 ifneq ("$(CBFLIB_DONT_USE_LOCAL_HDF5)","yes")
   HDF5_PREFIX ?= $(PWD)
-  HDF5 ?= hdf5-1.14.4-2
-  ifeq ("$(HDF5)","hdf5-1.14.4-2")
-    HDF5CFLAGS=-DH5_USE_110_API
-  endif
+  HDF5 ?= hdf5-1.14.6
+  HDF5CFLAGS=-DH5_USE_110_API
   HDF5dep = $(HDF5)
   HDF5_INSTALL = $(HDF5)_INSTALL
   ifneq ("$(MSYS2)","yes")
@@ -797,7 +795,7 @@ PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
-HDF5_URL	?= http://downloads.sf.net/cbflib/$(HDF5).tar.gz
+HDF5_URL	?= https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/$(HDF5).tar.gz
 ifneq ($(CBFLIB_DONT_USE_LOCAL_NUWEB),yes)
 NUWEB_URL	?= http://downloads.sf.net/cbflib/$(NUWEB_DEP).tar.gz
 endif
@@ -1065,7 +1063,7 @@ default:
 	@echo '   NUWEB_DEP = $(NUWEB_DEP)'
 	@echo '   NUWEB_DEP2 = $(NUWEB_DEP2)'
 	@echo ' '
-	@echo ' You will need either a system HDF5 1.12 or it to be installed here.'
+	@echo ' You will need either a system HDF5 >=1.10 or it to be installed here.'
 	@echo ' Check that CBFLIB_DONT_USE_LOCAL_HDF5 and HDF5 are defined correctly :'
 	@echo ' '
 	@echo ' The current values are:'

--- a/Makefile_MSYS2
+++ b/Makefile_MSYS2
@@ -373,10 +373,8 @@ endif
 
 ifneq ("$(CBFLIB_DONT_USE_LOCAL_HDF5)","yes")
   HDF5_PREFIX ?= $(PWD)
-  HDF5 ?= hdf5-1.14.4-2
-  ifeq ("$(HDF5)","hdf5-1.14.4-2")
-    HDF5CFLAGS=-DH5_USE_110_API
-  endif
+  HDF5 ?= hdf5-1.14.6
+  HDF5CFLAGS=-DH5_USE_110_API
   HDF5dep = $(HDF5)
   HDF5_INSTALL = $(HDF5)_INSTALL
   ifneq ("$(MSYS2)","yes")
@@ -782,7 +780,7 @@ PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
-HDF5_URL	?= http://downloads.sf.net/cbflib/$(HDF5).tar.gz
+HDF5_URL	?= https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/$(HDF5).tar.gz
 ifneq ($(CBFLIB_DONT_USE_LOCAL_NUWEB),yes)
 NUWEB_URL	?= http://downloads.sf.net/cbflib/$(NUWEB_DEP).tar.gz
 endif
@@ -1050,7 +1048,7 @@ default:
 	@echo '   NUWEB_DEP = $(NUWEB_DEP)'
 	@echo '   NUWEB_DEP2 = $(NUWEB_DEP2)'
 	@echo ' '
-	@echo ' You will need either a system HDF5 1.12 or it to be installed here.'
+	@echo ' You will need either a system HDF5 >=1.10 or it to be installed here.'
 	@echo ' Check that CBFLIB_DONT_USE_LOCAL_HDF5 and HDF5 are defined correctly :'
 	@echo ' '
 	@echo ' The current values are:'

--- a/Makefile_OSX
+++ b/Makefile_OSX
@@ -374,10 +374,8 @@ endif
 
 ifneq ("$(CBFLIB_DONT_USE_LOCAL_HDF5)","yes")
   HDF5_PREFIX ?= $(PWD)
-  HDF5 ?= hdf5-1.14.4-2
-  ifeq ("$(HDF5)","hdf5-1.14.4-2")
-    HDF5CFLAGS=-DH5_USE_110_API
-  endif
+  HDF5 ?= hdf5-1.14.6
+  HDF5CFLAGS=-DH5_USE_110_API
   HDF5dep = $(HDF5)
   HDF5_INSTALL = $(HDF5)_INSTALL
   ifneq ("$(MSYS2)","yes")
@@ -781,7 +779,7 @@ PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
-HDF5_URL	?= http://downloads.sf.net/cbflib/$(HDF5).tar.gz
+HDF5_URL	?= https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/$(HDF5).tar.gz
 ifneq ($(CBFLIB_DONT_USE_LOCAL_NUWEB),yes)
 NUWEB_URL	?= http://downloads.sf.net/cbflib/$(NUWEB_DEP).tar.gz
 endif
@@ -1049,7 +1047,7 @@ default:
 	@echo '   NUWEB_DEP = $(NUWEB_DEP)'
 	@echo '   NUWEB_DEP2 = $(NUWEB_DEP2)'
 	@echo ' '
-	@echo ' You will need either a system HDF5 1.12 or it to be installed here.'
+	@echo ' You will need either a system HDF5 >=1.10 or it to be installed here.'
 	@echo ' Check that CBFLIB_DONT_USE_LOCAL_HDF5 and HDF5 are defined correctly :'
 	@echo ' '
 	@echo ' The current values are:'

--- a/m4/Makefile.m4
+++ b/m4/Makefile.m4
@@ -381,10 +381,8 @@ endif
 
 ifneq ("$(CBFLIB_DONT_USE_LOCAL_HDF5)","yes")
   HDF5_PREFIX ?= $(PWD)
-  HDF5 ?= hdf5-1.14.4-2
-  ifeq ("$(HDF5)","hdf5-1.14.4-2")
-    HDF5CFLAGS=-DH5_USE_110_API
-  endif
+  HDF5 ?= hdf5-1.14.6
+  HDF5CFLAGS=-DH5_USE_110_API
   HDF5dep = $(HDF5)
   HDF5_INSTALL = $(HDF5)_INSTALL
   ifneq ("$(MSYS2)","yes")
@@ -1156,7 +1154,7 @@ PY3PLYURL       = http://downloads.sf.net/cbflib/$(PY3PLY).tar.gz
 endif
 REGEX_URL	?= http://downloads.sf.net/cbflib/$(REGEX).tar.gz
 TIFF_URL	?= http://downloads.sf.net/cbflib/$(TIFF).tar.gz
-HDF5_URL	?= http://downloads.sf.net/cbflib/$(HDF5).tar.gz
+HDF5_URL	?= https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/$(HDF5).tar.gz
 ifneq ($(CBFLIB_DONT_USE_LOCAL_NUWEB),yes)
 NUWEB_URL	?= http://downloads.sf.net/cbflib/$(NUWEB_DEP).tar.gz
 endif
@@ -1424,7 +1422,7 @@ default:
 	@echo ''`   NUWEB_DEP = $(NUWEB_DEP)''`
 	@echo ''`   NUWEB_DEP2 = $(NUWEB_DEP2)''`
 	@echo ''` ''`
-	@echo ''` You will need either a system HDF5 1.12 or it to be installed here.''`
+	@echo ''` You will need either a system HDF5 >=1.10 or it to be installed here.''`
 	@echo ''` Check that CBFLIB_DONT_USE_LOCAL_HDF5 and HDF5 are defined correctly :''`
 	@echo ''` ''`
 	@echo ''` The current values are:''`


### PR DESCRIPTION
Updated from 1.14.4-2. I do not understand why the Docker-make build does not _always_ fail with `byacc`.