### PR TITLE
Unbreak build with CBF_ENABLE_ULP set

### DIFF
--- a/examples/testhdf5.c
+++ b/examples/testhdf5.c
@@ -1121,11 +1121,13 @@ static testResult_t test_H5Dinsert
 	TEST_CBF_PASS(cbf_H5Dinsert(dset,off,std,cnt,buf,val,type));
 	{/* post-conditions */
 		CBF_CALL(cbf_H5Dread2(dset,off,std,cnt,valBuf,type));
-		if (CBF_SUCCESS==error) TEST(!cmp(val,valBuf,length
+		if (CBF_SUCCESS==error) {
 #ifdef CBF_USE_ULP
-                                          ,cmp_params
+			TEST(!cmp(val,valBuf,length,cmp_params));
+#else
+			TEST(!cmp(val,valBuf,length));
 #endif
-                                          ));
+		}
 	}
     
 	return r;

--- a/src/cbf_hdf5.c
+++ b/src/cbf_hdf5.c
@@ -26460,6 +26460,10 @@ static int process_DiffrnScanAxisCache(cbf_node * const category,
         const hsize_t max[] = {1};
         const hsize_t cnk[] = {1};
         hsize_t buf[] = {0};
+#ifdef CBF_USE_ULP
+        cmp_double_param_t cmp_double_params;
+        void * cmp_params = &cmp_double_params;
+#endif
 
 
         if (!handle || !h5handle || !matrix) return CBF_ARGUMENT;


### PR DESCRIPTION
_CBFlib_ does not compile if `CBF_ENABLE_ULP` is enabled. This patch rescues the build and passes the `testulp` test.