### PR TITLE
Provide Windows replacement implementation for realpath(3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1110,7 +1110,8 @@ target_link_libraries(cbf_standardize_numbers
   cbf
   "${libm}")
 if(NOT HAVE_FGETLN)
-  target_sources(cbf_standardize_numbers PRIVATE "${CBF__SRC}/fgetln.c")
+  target_sources(cbf_standardize_numbers
+    PRIVATE "${CBF__SRC}/fgetln.c")
 endif()
 
 add_executable(cbf_tail

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,12 +337,18 @@ if (NOT CMAKE_BUILD_TYPE)
 endif (NOT CMAKE_BUILD_TYPE)
 
 
-# Check for missing functions: fgetln(3) is in 4.4BSD; regcomp(3) is
-# in POSIX.1-2001, POSIX.1-2008.
+# Check for missing functions: fgetln(3) is in 4.4BSD; realpath(3) is
+# in 4.4BSD, POSIX.1-2001; regcomp(3) is in POSIX.1-2001,
+# POSIX.1-2008.
 include(CheckSymbolExists)
 check_symbol_exists(fgetln "stdio.h" HAVE_FGETLN)
 if(HAVE_FGETLN)
   add_compile_definitions("HAVE_FGETLN")
+endif()
+
+check_symbol_exists(realpath "stdlib.h" HAVE_REALPATH)
+if(HAVE_REALPATH)
+  add_compile_definitions("HAVE_REALPATH")
 endif()
 
 check_symbol_exists(regcomp "regex.h" HAVE_REGEX)
@@ -818,6 +824,10 @@ if(CBF_ENABLE_ULP)
     PUBLIC CBF_USE_ULP)
   target_sources(cbf
     PRIVATE "${CBF__SRC}/cbf_ulp.c")
+endif()
+if(NOT HAVE_REALPATH)
+  target_sources(cbf
+    PRIVATE "${CBF__SRC}/realpath.c")
 endif()
 
 set_target_properties(cbf PROPERTIES OUTPUT_NAME "cbf")

--- a/Makefile
+++ b/Makefile
@@ -736,9 +736,9 @@ endif
 CC	= gcc
 C++	= g++
 ifneq ($(CBFDEBUG),)
-CFLAGS  = -g -O0 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DCBFDEBUG=1  $(HDF5CFLAGS)
+CFLAGS  = -g -O0 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DCBFDEBUG=1  $(HDF5CFLAGS)
 else
-CFLAGS  = -g -O3 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O3 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
 endif
 LDFLAGS =
 F90C = gfortran

--- a/Makefile_LINUX
+++ b/Makefile_LINUX
@@ -735,7 +735,7 @@ endif
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz

--- a/Makefile_OSX
+++ b/Makefile_OSX
@@ -736,7 +736,7 @@ endif
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -std=c99 -pedantic $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DHAVE_REALPATH $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz

--- a/examples/cbf_standardize_numbers.c
+++ b/examples/cbf_standardize_numbers.c
@@ -15,7 +15,11 @@
 #include <string.h>
 
 
-char * fgetln(FILE *, size_t *);
+#ifndef HAVE_FGETLN
+#    define fgetln _cbf_fgetln
+char *
+_cbf_fgetln(FILE *stream, size_t *len);
+#endif
 
 void usage ( void ) {
     

--- a/m4/Makefile.m4
+++ b/m4/Makefile.m4
@@ -743,7 +743,7 @@ endif
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -std=c99 -pedantic $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DHAVE_REALPATH $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -769,7 +769,7 @@ cbf_system,`OSX_gcc42',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -std=c99 -pedantic $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DHAVE_REALPATH $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -795,7 +795,7 @@ cbf_system,`OSX_gcc42_DMALLOC',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DDMALLOC -DDMALLOC_FUNC_CHECK -I$(HOME)/include $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DDMALLOC -DDMALLOC_FUNC_CHECK -DHAVE_REALPATH -I$(HOME)/include $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -822,7 +822,7 @@ cbf_system,`LINUX_64',`
 #########################################################
 CC	= gcc -m64
 C++	= g++ -m64
-CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran -m64
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -850,7 +850,7 @@ cbf_system,`LINUX_gcc42',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -877,7 +877,7 @@ cbf_system,`LINUX',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -905,7 +905,7 @@ cbf_system,`LINUX_gcc42_DMALLOC', `
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing \
+CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing \
 	  -DDMALLOC -DDMALLOC_FUNC_CHECK  $(HDF5CFLAGS)  -I$(HOME)/include
 LDFLAGS =
 F90C = gfortran
@@ -932,7 +932,7 @@ cbf_system,`LINUX_DMALLOC',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing \
+CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing \
 	  -DDMALLOC -DDMALLOC_FUNC_CHECK   $(HDF5CFLAGS) -I$(HOME)/include
 LDFLAGS =
 F90C = gfortran
@@ -1105,9 +1105,9 @@ RANLIB  = ',
 CC	= gcc
 C++	= g++
 ifneq ($(CBFDEBUG),)
-CFLAGS  = -g -O0 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DCBFDEBUG=1  $(HDF5CFLAGS)
+CFLAGS  = -g -O0 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DCBFDEBUG=1  $(HDF5CFLAGS)
 else
-CFLAGS  = -g -O3 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O3 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
 endif
 LDFLAGS =
 F90C = gfortran

--- a/src/cbf_hdf5.c
+++ b/src/cbf_hdf5.c
@@ -283,6 +283,12 @@ extern "C" {
 #include <assert.h>
 #include <errno.h>
 
+#ifndef HAVE_REALPATH
+#define realpath _cbf_realpath
+char *
+_cbf_realpath(const char *path, char *resolved_path);
+#endif
+
     static int cbf_find_array_data_h5type
     (hid_t * const type,
      unsigned int bits,

--- a/src/fgetln.c
+++ b/src/fgetln.c
@@ -31,9 +31,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef HAVE_fgetln
 char *
-fgetln(FILE *stream, size_t *len)
+_cbf_fgetln(FILE *stream, size_t *len)
 {
   static char *buf = NULL;
   static size_t buflen = 0;
@@ -63,4 +62,3 @@ fgetln(FILE *stream, size_t *len)
   *len = strlen(buf);
   return buf;
 }
-#endif /* !defined(HAVE_fgetln) */

--- a/src/realpath.c
+++ b/src/realpath.c
@@ -1,6 +1,19 @@
-#include <stdlib.h>
-char *realpath(const char *path, char *resolved_path)
-{
-    return 0;
-}
+#ifdef _WIN32
+#    include <windows.h>
+#endif
 
+char *
+_cbf_realpath(const char *path, char *resolved_path)
+{
+#ifdef _WIN32
+    if (path == NULL) {
+        errno = EINVAL;
+        return (NULL);
+    }
+
+    return (_fullpath(resolved_path, path, MAX_PATH));
+#else
+    errno = ENOSYS;
+    return (NULL);
+#endif
+}


### PR DESCRIPTION
This seems to be sufficient to make _CBFlib_ build with _CMake_ on _MSYS2_/_UCRT64_. For a static build (_i.e._ no Java or Python) with pregenerated Fortran sources and all external dependencies satisfied by _Pacman_ (except _CQRlib_, for which there is no package), 157 out of 161 (98%) _CTest_ tests pass.