### PR TITLE
Guard inclusion of unistd.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,14 @@ if (NOT CMAKE_BUILD_TYPE)
 endif (NOT CMAKE_BUILD_TYPE)
 
 
+# Check for missing header files.
+include(CheckIncludeFile)
+check_include_file("unistd.h" HAVE_UNISTD_H)
+if(HAVE_UNISTD_H)
+  add_compile_definitions("HAVE_UNISTD_H")
+endif()
+
+
 # Check for missing functions: fgetln(3) is in 4.4BSD; realpath(3) is
 # in 4.4BSD, POSIX.1-2001; regcomp(3) is in POSIX.1-2001,
 # POSIX.1-2008.

--- a/Makefile
+++ b/Makefile
@@ -736,9 +736,9 @@ endif
 CC	= gcc
 C++	= g++
 ifneq ($(CBFDEBUG),)
-CFLAGS  = -g -O0 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DCBFDEBUG=1  $(HDF5CFLAGS)
+CFLAGS  = -g -O0 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DHAVE_REALPATH -DCBFDEBUG=1 -DHAVE_UNISTD_H $(HDF5CFLAGS)
 else
-CFLAGS  = -g -O3 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O3 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 endif
 LDFLAGS =
 F90C = gfortran

--- a/Makefile_LINUX
+++ b/Makefile_LINUX
@@ -735,7 +735,7 @@ endif
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz

--- a/Makefile_MINGW
+++ b/Makefile_MINGW
@@ -737,7 +737,7 @@ endif
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -I/usr/include -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -I/usr/include -fno-strict-aliasing -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = g95
 F90FLAGS = -g

--- a/Makefile_MSYS2
+++ b/Makefile_MSYS2
@@ -736,7 +736,8 @@ endif
 CC	= gcc
 C++	= g++
 CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -DH5_HAVE_WIN32_API \
-  -DH5_HAVE_MINGW -DH5_USE_110_API -fno-strict-aliasing  $(HDF5CFLAGS)
+  -DH5_HAVE_MINGW -DH5_USE_110_API -fno-strict-aliasing -DHAVE_UNISTD_H \
+  $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz

--- a/Makefile_OSX
+++ b/Makefile_OSX
@@ -736,7 +736,7 @@ endif
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DHAVE_REALPATH $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz

--- a/examples/cbf2nexus.c
+++ b/examples/cbf2nexus.c
@@ -239,7 +239,9 @@
 #include <ctype.h>
 #include <time.h>
 #include <errno.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <stdint.h>
 
 #include "cbf.h"

--- a/examples/cif2c.c
+++ b/examples/cif2c.c
@@ -303,7 +303,9 @@
 #include <time.h>
 #include <errno.h>
 #include "cbf_getopt.h"
-#include <unistd.h>
+#ifdef HAVE_UNISTD_H
+#  include <unistd.h>
+#endif
 
 #define C2CBUFSIZ 8192
 

--- a/examples/cif2cbf.c
+++ b/examples/cif2cbf.c
@@ -498,7 +498,9 @@
 #include <time.h>
 #include <errno.h>
 #include "cbf_getopt.h"
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 
 #define C2CBUFSIZ 8192
 #define NUMDICTS 50

--- a/examples/convert_image.c
+++ b/examples/convert_image.c
@@ -305,7 +305,9 @@
 #include <math.h>
 #include <errno.h>
 #include "cbf_getopt.h"
-#include <unistd.h>
+#ifdef HAVE_UNISTD_H
+#  include <unistd.h>
+#endif
 
 
 

--- a/examples/convert_minicbf.c
+++ b/examples/convert_minicbf.c
@@ -315,7 +315,9 @@
 #include <math.h>
 #include <errno.h>
 #include "cbf_getopt.h"
-#include <unistd.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
 
 #define CVTBUFSIZ 8192
 

--- a/examples/dectris_cbf_template_test/cbf_template_t.c
+++ b/examples/dectris_cbf_template_test/cbf_template_t.c
@@ -35,7 +35,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/examples/img2cif.c
+++ b/examples/img2cif.c
@@ -290,7 +290,9 @@
 #include <ctype.h>
 #include <time.h>
 #include <errno.h>
-#include <unistd.h>
+#ifdef HAVE_UNISTD_H
+#  include <unistd.h>
+#endif
 
 #include "cbf_getopt.h"
 

--- a/examples/minicbf2nexus.c
+++ b/examples/minicbf2nexus.c
@@ -253,7 +253,9 @@
 #include <ctype.h>
 #include <time.h>
 #include <errno.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #ifdef CBF_USE_ULP
 #include <stdint.h>
 #endif

--- a/examples/nexus2cbf.c
+++ b/examples/nexus2cbf.c
@@ -239,7 +239,6 @@
 #include <ctype.h>
 #include <time.h>
 #include <errno.h>
-#include <unistd.h>
 #include <stdint.h>
 
 #include <hdf5.h>

--- a/examples/sequence_match.c
+++ b/examples/sequence_match.c
@@ -34,7 +34,9 @@
 #include <time.h>
 #include <errno.h>
 #include "cbf_getopt.h"
-#include <unistd.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 

--- a/examples/testflat.c
+++ b/examples/testflat.c
@@ -243,7 +243,6 @@
 #include <ctype.h>
 #include <math.h>
 #include <errno.h>
-#include <unistd.h>
 
 
 int local_exit (int status);

--- a/examples/testflatpacked.c
+++ b/examples/testflatpacked.c
@@ -243,7 +243,6 @@
 #include <ctype.h>
 #include <math.h>
 #include <errno.h>
-#include <unistd.h>
 
 
 int local_exit (int status);

--- a/examples/testreals.c
+++ b/examples/testreals.c
@@ -243,7 +243,6 @@
 #include <ctype.h>
 #include <math.h>
 #include <errno.h>
-#include <unistd.h>
 
 
 int local_exit (int status);

--- a/m4/Makefile.m4
+++ b/m4/Makefile.m4
@@ -743,7 +743,7 @@ endif
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DHAVE_REALPATH $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -769,7 +769,7 @@ cbf_system,`OSX_gcc42',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DHAVE_REALPATH $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -795,7 +795,7 @@ cbf_system,`OSX_gcc42_DMALLOC',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DDMALLOC -DDMALLOC_FUNC_CHECK -DHAVE_REALPATH -I$(HOME)/include $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -std=c99 -pedantic -DDMALLOC -DDMALLOC_FUNC_CHECK -I$(HOME)/include -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -822,7 +822,7 @@ cbf_system,`LINUX_64',`
 #########################################################
 CC	= gcc -m64
 C++	= g++ -m64
-CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran -m64
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -850,7 +850,7 @@ cbf_system,`LINUX_gcc42',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -877,7 +877,7 @@ cbf_system,`LINUX',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -905,8 +905,9 @@ cbf_system,`LINUX_gcc42_DMALLOC', `
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing \
-	  -DDMALLOC -DDMALLOC_FUNC_CHECK  $(HDF5CFLAGS)  -I$(HOME)/include
+CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing \
+	  -DDMALLOC -DDMALLOC_FUNC_CHECK -DHAVE_REALPATH \
+	  -DHAVE_UNISTD_H $(HDF5CFLAGS) -I$(HOME)/include
 LDFLAGS =
 F90C = gfortran
 F90FLAGS = -g -fno-range-check -fno-range-check
@@ -932,8 +933,9 @@ cbf_system,`LINUX_DMALLOC',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing \
-	  -DDMALLOC -DDMALLOC_FUNC_CHECK   $(HDF5CFLAGS) -I$(HOME)/include
+CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing \
+	  -DDMALLOC -DDMALLOC_FUNC_CHECK -DHAVE_REALPATH \
+	  -DHAVE_UNISTD_H $(HDF5CFLAGS) -I$(HOME)/include
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -960,7 +962,7 @@ cbf_system,`AIX',`
 #########################################################
 CC	= xlc
 C++	= xlC
-CFLAGS  = -g -O2  -Wall  $(HDF5CFLAGS)
+CFLAGS  = -g -O2  -Wall -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = xlf90
 F90FLAGS = -g -qsuffix=f=f90
@@ -980,7 +982,7 @@ cbf_system,`MINGW',`
 #########################################################
 CC	= gcc
 C++	= g++
-CFLAGS  = -g -O2 -Wall -I/usr/include -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O2 -Wall -I/usr/include -fno-strict-aliasing -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C = g95
 F90FLAGS = -g
@@ -1019,7 +1021,7 @@ cbf_system,`MINGW_CROSS',`
 #  use default paths for utilities
 #
 #########################################################
-CFLAGS  = -m64 -g -O2 -Wall -fno-strict-aliasing -DH5_HAVE_MINGW
+CFLAGS  = -m64 -g -O2 -Wall -fno-strict-aliasing -DH5_HAVE_MINGW -DHAVE_UNISTD_H
 LDFLAGS =
 F90FLAGS = -g
 F90LDFLAGS =
@@ -1049,7 +1051,8 @@ cbf_system,`MSYS2',`
 CC	= gcc
 C++	= g++
 CFLAGS  = -g -O2 -Wall -D_USE_XOPEN_EXTENDED -DH5_HAVE_WIN32_API \
-  -DH5_HAVE_MINGW -DH5_USE_110_API -fno-strict-aliasing  $(HDF5CFLAGS)
+  -DH5_HAVE_MINGW -DH5_USE_110_API -fno-strict-aliasing -DHAVE_UNISTD_H \
+  $(HDF5CFLAGS)
 LDFLAGS =
 F90C = gfortran
 #F90FLAGS = -g -fno-range-check -fallow-invalid-boz
@@ -1077,7 +1080,7 @@ cbf_system,`IRIX_gcc',`
 #########################################################
 CC      = gcc
 C++     = g++
-CFLAGS  = -g -O2  -Wall   $(HDF5CFLAGS)
+CFLAGS  = -g -O2  -Wall -DHAVE_UNISTD_H $(HDF5CFLAGS)
 LDFLAGS =
 F90C    =
 F90FLAGS =
@@ -1105,9 +1108,9 @@ RANLIB  = ',
 CC	= gcc
 C++	= g++
 ifneq ($(CBFDEBUG),)
-CFLAGS  = -g -O0 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DCBFDEBUG=1  $(HDF5CFLAGS)
+CFLAGS  = -g -O0 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DCBFDEBUG=1 -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 else
-CFLAGS  = -g -O3 -Wall -DHAVE_REALPATH -D_USE_XOPEN_EXTENDED -fno-strict-aliasing  $(HDF5CFLAGS)
+CFLAGS  = -g -O3 -Wall -D_USE_XOPEN_EXTENDED -fno-strict-aliasing -DHAVE_REALPATH -DHAVE_UNISTD_H $(HDF5CFLAGS)
 endif
 LDFLAGS =
 F90C = gfortran

--- a/src/cbf_context.c
+++ b/src/cbf_context.c
@@ -261,7 +261,9 @@ extern "C" {
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
-#include <unistd.h>
+#ifdef HAVE_UNISTD_H
+  #include <unistd.h>
+#endif
 #include <fcntl.h>
 #ifdef _WIN32
   #include <direct.h>

--- a/src/cbf_uncompressed.c
+++ b/src/cbf_uncompressed.c
@@ -261,6 +261,8 @@ extern "C" {
 #if !defined(_MSC_VER)
 #define __USE_XOPEN
 #define _XOPEN_SOURCE
+#endif
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Only include `unistd.h` where needed.