### PR TITLE
Use explicit Fortran formats

### DIFF
--- a/m4/fcb_read_xds_i2.m4
+++ b/m4/fcb_read_xds_i2.m4
@@ -193,7 +193,7 @@ m4_include(`fcblib_defines.m4')
       DO I = 1,NX
       IF (JFRAME(I,J).NE.PREV_ELEMENT) THEN
         PREV_ELEMENT = JFRAME(I,J)
-        PRINT *,"ARRAY(",I+(J-1)*NX,") =",JFRAME(I,J)
+        PRINT "(A7,I12,A4,I12)","ARRAY(",I+(J-1)*NX,") =",JFRAME(I,J)
       ENDIF
       IFRAME(I+(J-1)*NX) = CNT2PIX(JFRAME(I,J))
       END DO

--- a/m4/test_xds_binary.m4
+++ b/m4/test_xds_binary.m4
@@ -16,8 +16,8 @@ m4_include(`fcblib_defines.m4')`      PROGRAM TEST
 	DO I = 1,1000
 	DO J = 1,1000
 	  IF (IFRAME(I,J).NE.DPREV) THEN
-	    PRINT *,"ROW ", I, ":"
-	    PRINT *,(IFRAME(I,K),K=1,1000)
+	    PRINT "(A4,I13,A2)","ROW", I, ":"
+	    PRINT "(1000I7)",(IFRAME(I,K),K=1,1000)
 	    DPREV = IFRAME(I,1000)
 	    GO TO 1000
 	  ENDIF


### PR DESCRIPTION
Use _gfortran_'s default output formats to avoid breaking the tests. Recovers build with _flang_.