### PR TITLE
Unbreak CMake build on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,6 +676,7 @@ set(
     ${CBF__SRC}/cbf.c
     "${CBF__SRC}/cbf_airy_disk.c"
     ${CBF__SRC}/cbf_alloc.c
+    "${CBF__SRC}/cbf_array2minicbf.c"
     ${CBF__SRC}/cbf_ascii.c
     ${CBF__SRC}/cbf_binary.c
     ${CBF__SRC}/cbf_byte_offset.c
@@ -736,6 +737,7 @@ set(
 	CBF_HEADERS
 	${CBF__INCLUDE}/cbf.h			
     ${CBF__INCLUDE}/cbf_alloc.h
+    "${CBF__INCLUDE}/cbf_array2minicbf.h"
     ${CBF__INCLUDE}/cbf_ascii.h
     ${CBF__INCLUDE}/cbf_binary.h		
     ${CBF__INCLUDE}/cbf_byte_offset.h


### PR DESCRIPTION
Compile with `cbf_array2minicbf.c`.  Not spotted earlier because by default, GNU ld allows undefined symbols when creating shared libraries. Cannot use _flang_ on macOS yet, because _CMake_ insists on invoking it with the unknown `-dynamiclib` argument.